### PR TITLE
Allow QPD-3 to be repeated for V25

### DIFF
--- a/NHapi20/NHapi.Model.V24/Segment/QPD.cs
+++ b/NHapi20/NHapi.Model.V24/Segment/QPD.cs
@@ -32,7 +32,7 @@ public class QPD : AbstractSegment  {
     try {
        this.add(typeof(CE), true, 1, 250, new System.Object[]{message}, "Message Query Name");
        this.add(typeof(ST), false, 1, 32, new System.Object[]{message}, "Query Tag");
-       this.add(typeof(Varies), false, 1, 256, new System.Object[]{message}, "User Parameters (in successive fields)");
+       this.add(typeof(Varies), false, 0, 256, new System.Object[]{message}, "User Parameters (in successive fields)");
     } catch (HL7Exception he) {
         HapiLogFactory.GetHapiLog(GetType()).Error("Can't instantiate " + GetType().Name, he);
     }

--- a/NHapi20/NHapi.Model.V25/Segment/QPD.cs
+++ b/NHapi20/NHapi.Model.V25/Segment/QPD.cs
@@ -32,7 +32,7 @@ public class QPD : AbstractSegment  {
     try {
        this.add(typeof(CE), true, 1, 250, new System.Object[]{message}, "Message Query Name");
        this.add(typeof(ST), false, 1, 32, new System.Object[]{message}, "Query Tag");
-       this.add(typeof(Varies), false, 1, 256, new System.Object[]{message}, "User Parameters (in successive fields)");
+       this.add(typeof(Varies), false, 0, 256, new System.Object[]{message}, "User Parameters (in successive fields)");
     } catch (HL7Exception he) {
         HapiLogFactory.GetHapiLog(GetType()).Error("Can't instantiate " + GetType().Name, he);
     }

--- a/NHapi20/NHapi.Model.V251/Segment/QPD.cs
+++ b/NHapi20/NHapi.Model.V251/Segment/QPD.cs
@@ -32,7 +32,7 @@ public class QPD : AbstractSegment  {
     try {
        this.add(typeof(CE), true, 1, 250, new System.Object[]{message}, "Message Query Name");
        this.add(typeof(ST), false, 1, 32, new System.Object[]{message}, "Query Tag");
-       this.add(typeof(Varies), false, 1, 256, new System.Object[]{message}, "User Parameters (in successive fields)");
+       this.add(typeof(Varies), false, 0, 256, new System.Object[]{message}, "User Parameters (in successive fields)");
     } catch (HL7Exception he) {
         HapiLogFactory.GetHapiLog(GetType()).Error("Can't instantiate " + GetType().Name, he);
     }

--- a/NHapi20/NHapi.Model.V26/Segment/QPD.cs
+++ b/NHapi20/NHapi.Model.V26/Segment/QPD.cs
@@ -32,7 +32,7 @@ public class QPD : AbstractSegment  {
     try {
        this.add(typeof(CWE), true, 1, 250, new System.Object[]{message}, "Message Query Name");
        this.add(typeof(ST), false, 1, 32, new System.Object[]{message}, "Query Tag");
-       this.add(typeof(Varies), false, 1, 256, new System.Object[]{message}, "User Parameters (in successive fields)");
+       this.add(typeof(Varies), false, 0, 256, new System.Object[]{message}, "User Parameters (in successive fields)");
     } catch (HL7Exception he) {
         HapiLogFactory.GetHapiLog(GetType()).Error("Can't instantiate " + GetType().Name, he);
     }

--- a/NHapi20/NHapi.Model.V27/Segment/QPD.cs
+++ b/NHapi20/NHapi.Model.V27/Segment/QPD.cs
@@ -32,7 +32,7 @@ public class QPD : AbstractSegment  {
     try {
        this.add(typeof(CWE), true, 1, 0, new System.Object[]{message}, "Message Query Name");
        this.add(typeof(ST), false, 1, 0, new System.Object[]{message}, "Query Tag");
-       this.add(typeof(Varies), false, 1, 0, new System.Object[]{message}, "User Parameters (in successive fields)");
+       this.add(typeof(Varies), false, 0, 0, new System.Object[]{message}, "User Parameters (in successive fields)");
     } catch (HL7Exception he) {
         HapiLogFactory.GetHapiLog(GetType()).Error("Can't instantiate " + GetType().Name, he);
     }

--- a/NHapi20/NHapi.Model.V271/Segment/QPD.cs
+++ b/NHapi20/NHapi.Model.V271/Segment/QPD.cs
@@ -32,7 +32,7 @@ public class QPD : AbstractSegment  {
     try {
        this.add(typeof(CWE), true, 1, 0, new System.Object[]{message}, "Message Query Name");
        this.add(typeof(ST), false, 1, 0, new System.Object[]{message}, "Query Tag");
-       this.add(typeof(Varies), false, 1, 0, new System.Object[]{message}, "User Parameters (in successive fields)");
+       this.add(typeof(Varies), false, 0, 0, new System.Object[]{message}, "User Parameters (in successive fields)");
     } catch (HL7Exception he) {
         HapiLogFactory.GetHapiLog(GetType()).Error("Can't instantiate " + GetType().Name, he);
     }

--- a/NHapi20/NHapi.Model.V28/Segment/QPD.cs
+++ b/NHapi20/NHapi.Model.V28/Segment/QPD.cs
@@ -32,7 +32,7 @@ public class QPD : AbstractSegment  {
     try {
        this.add(typeof(CWE), true, 1, 0, new System.Object[]{message}, "Message Query Name");
        this.add(typeof(ST), false, 1, 0, new System.Object[]{message}, "Query Tag");
-       this.add(typeof(Varies), false, 1, 0, new System.Object[]{message}, "User Parameters (in successive fields)");
+       this.add(typeof(Varies), false, 0, 0, new System.Object[]{message}, "User Parameters (in successive fields)");
     } catch (HL7Exception he) {
         HapiLogFactory.GetHapiLog(GetType()).Error("Can't instantiate " + GetType().Name, he);
     }

--- a/NHapi20/NHapi.Model.V281/Segment/QPD.cs
+++ b/NHapi20/NHapi.Model.V281/Segment/QPD.cs
@@ -32,7 +32,7 @@ public class QPD : AbstractSegment  {
     try {
        this.add(typeof(CWE), true, 1, 0, new System.Object[]{message}, "Message Query Name");
        this.add(typeof(ST), false, 1, 0, new System.Object[]{message}, "Query Tag");
-       this.add(typeof(Varies), false, 1, 0, new System.Object[]{message}, "User Parameters (in successive fields)");
+       this.add(typeof(Varies), false, 0, 0, new System.Object[]{message}, "User Parameters (in successive fields)");
     } catch (HL7Exception he) {
         HapiLogFactory.GetHapiLog(GetType()).Error("Can't instantiate " + GetType().Name, he);
     }


### PR DESCRIPTION
For message QPB^Q22 the standard allow more than two repetitions of segment QPD-3 into the QPD for query patients by name, surname and date of birth for example.
The change proposed allow that to be done.