### PR TITLE
Parsing fixes for Message v2.1 OBX and ORU

### DIFF
--- a/NHapi20/NHapi.Base/Parser/PipeParser.cs
+++ b/NHapi20/NHapi.Base/Parser/PipeParser.cs
@@ -383,8 +383,8 @@ namespace NHapi.Base.Parser
 				}
 			}
 
-			//set data type of OBX-5
-			if (destination.GetType().FullName.IndexOf("OBX") >= 0)
+			//set data type of OBX-5 - Except in 2.1 message, in a 2.1 Message OBX-2 is Optional and OBX-5 can only be ST
+			if (destination.GetType().FullName.IndexOf("OBX") >= 0 && destination.Message.Version != "2.1")
 			{
 				Varies.fixOBX5(destination, Factory);
 			}

--- a/NHapi20/NHapi.Model.V21/Datatype/CM.cs
+++ b/NHapi20/NHapi.Model.V21/Datatype/CM.cs
@@ -20,5 +20,9 @@ namespace NHapi.Model.V21.Datatype
             : base(message)
         {
         }
+
+	    public CM(IMessage message, string test) : base(message)
+	    {
+	    }
     }
 }


### PR DESCRIPTION
This small patch fixes errors thrown in #63 as well as #84 Applying these fixes as per inbound HIE data found in a real use case.