### PR TITLE
Various Issue fixes

### DIFF
--- a/Hl7Models.sln
+++ b/Hl7Models.sln
@@ -40,6 +40,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{14D20F5F-87E7-41BD-BE24-991081E0DE60}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		global.json = global.json
 		NHapi.snk = NHapi.snk
 		README.md = README.md
 	EndProjectSection

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "3.1.301",
+    "rollForward": "latestFeature"
+  },
+  "projects": []
+}

--- a/nHapi.sln
+++ b/nHapi.sln
@@ -16,11 +16,12 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F462762A-D1DC-42AE-8E52-4BD3CC4590E4}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		global.json = global.json
 		NHapi.snk = NHapi.snk
 		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NHapi.SourceGeneration", "src\NHapi.SourceGeneration\NHapi.SourceGeneration.csproj", "{D9A637CE-C1B6-499C-B81B-82AE30580394}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NHapi.SourceGeneration", "src\NHapi.SourceGeneration\NHapi.SourceGeneration.csproj", "{D9A637CE-C1B6-499C-B81B-82AE30580394}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/NHapi.Base/Model/GenericComposite.cs
+++ b/src/NHapi.Base/Model/GenericComposite.cs
@@ -35,11 +35,19 @@ namespace NHapi.Base.Model
 		private ArrayList components;
 		private IMessage message;
 
-		/// <summary>Creates a new instance of GenericComposite </summary>
-		public GenericComposite(IMessage message)
-			: base(message)
+		/// <summary>Creates a new instance of GenericComposite</summary>
+		/// <param name="theMessage">message to which this Type belongs</param>
+		public GenericComposite(IMessage theMessage)
+			: this(theMessage, null)
 		{
-			this.message = message;
+		}
+
+		/// <summary>Creates a new instance of GenericComposite</summary>
+		/// <param name="theMessage">message to which this Type belongs</param>
+		/// <param name="description">The description of this type</param>
+		public GenericComposite(IMessage theMessage, string description)
+			: base(theMessage, description)
+		{
 			components = new ArrayList(20);
 		}
 

--- a/src/NHapi.Base/Model/Primitive/DT.cs
+++ b/src/NHapi.Base/Model/Primitive/DT.cs
@@ -1,43 +1,43 @@
 /*
-  The contents of this file are subject to the Mozilla Public License Version 1.1
-  (the "License"); you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at http://www.mozilla.org/MPL/
-  Software distributed under the License is distributed on an "AS IS" basis,
-  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
-  specific language governing rights and limitations under the License.
-  
-  The Original Code is "DT.java".  Description:
-  "Note: The class description below has been excerpted from the Hl7 2.3.0 documentation"
-  
-  The Initial Developer of the Original Code is University Health Network. Copyright (C)
-  2005.  All Rights Reserved.
-  
-  Contributor(s): ______________________________________.
-  
-  Alternatively, the contents of this file may be used under the terms of the
-  GNU General Public License (the "GPL"), in which case the provisions of the GPL are
-  applicable instead of those above.  If you wish to allow use of your version of this
-  file only under the terms of the GPL and not to allow others to use your version
-  of this file under the MPL, indicate your decision by deleting  the provisions above
-  and replace  them with the notice and other provisions required by the GPL License.
-  If you do not delete the provisions above, a recipient may use your version of
-  this file under either the MPL or the GPL.
+	The contents of this file are subject to the Mozilla Public License Version 1.1
+	(the "License"); you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.mozilla.org/MPL/
+	Software distributed under the License is distributed on an "AS IS" basis,
+	WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+	specific language governing rights and limitations under the License.
+
+	The Original Code is "DT.java".  Description:
+	"Note: The class description below has been excerpted from the Hl7 2.3.0 documentation"
+
+	The Initial Developer of the Original Code is University Health Network. Copyright (C)
+	2005.  All Rights Reserved.
+
+	Contributor(s): ______________________________________.
+
+	Alternatively, the contents of this file may be used under the terms of the
+	GNU General Public License (the "GPL"), in which case the provisions of the GPL are
+	applicable instead of those above.  If you wish to allow use of your version of this
+	file only under the terms of the GPL and not to allow others to use your version
+	of this file under the MPL, indicate your decision by deleting  the provisions above
+	and replace  them with the notice and other provisions required by the GPL License.
+	If you do not delete the provisions above, a recipient may use your version of
+	this file under either the MPL or the GPL.
 */
 
 using System;
 
 namespace NHapi.Base.Model.Primitive
 {
-   /// <summary> Represents an HL7 DT (date) datatype.   
-   /// 
-   /// </summary>
-   /// <author>  <a href="mailto:neal.acharya@uhn.on.ca">Neal Acharya</a>
-   /// </author>
-   /// <author>  <a href="mailto:bryan.tripp@uhn.on.ca">Bryan Tripp</a>
-   /// </author>
-   /// <version>  $Revision: 1.3 $ updated on $Date: 2005/06/08 00:28:25 $ by $Author: bryan_tripp $
-   /// </version>
-   public abstract class DT : AbstractPrimitive
+	/// <summary>
+	///	Represents an HL7 DT (date) datatype.
+	/// </summary>
+	/// <author>  <a href="mailto:neal.acharya@uhn.on.ca">Neal Acharya</a>
+	/// </author>
+	/// <author>  <a href="mailto:bryan.tripp@uhn.on.ca">Bryan Tripp</a>
+	/// </author>
+	/// <version>  $Revision: 1.3 $ updated on $Date: 2005/06/08 00:28:25 $ by $Author: bryan_tripp $
+	/// </version>
+	public abstract class DT : AbstractPrimitive
 	{
 		private CommonDT Detail
 		{
@@ -51,10 +51,12 @@ namespace NHapi.Base.Model.Primitive
 			}
 		}
 
-		/// <throws>  DataTypeException if the value is incorrectly formatted and either validation is  </throws>
-		/// <summary>      enabled for this primitive or detail setters / getters have been called, forcing further
-		/// parsing.   
-		/// </summary>
+		
+		/// <value>
+		/// enabled for this primitive or detail setters / getters have been
+		/// called, forcing further parsing.
+		/// </value>
+		/// <throws ref="DataTypeException"/>if the value is incorrectly formatted and either validation is</throws>
 		public override String Value
 		{
 			get
@@ -121,20 +123,17 @@ namespace NHapi.Base.Model.Primitive
 
 		private CommonDT myDetail;
 
-		/// <param name="theMessage">message to which this Type belongs
-		/// </param>
-		public DT(IMessage theMessage)
+		/// <summary>Construct the type</summary>
+		/// <param name="theMessage">message to which this Type belongs</param>
+		protected DT(IMessage theMessage)
 			: base(theMessage)
 		{
 		}
 
-
-		/// <summary>
-		/// DT class
-		/// </summary>
-		/// <param name="theMessage"></param>
-		/// <param name="description"></param>
-		public DT(IMessage theMessage, string description)
+		///<summary>Construct the type</summary>
+		///<param name="theMessage">message to which this Type belongs</param>
+		///<param name="description">The description of this type</param>
+		protected DT(IMessage theMessage, string description)
 			: base(theMessage, description)
 		{
 		}

--- a/src/NHapi.Base/Model/Primitive/ID.cs
+++ b/src/NHapi.Base/Model/Primitive/ID.cs
@@ -1,28 +1,28 @@
 /*
-  The contents of this file are subject to the Mozilla Public License Version 1.1
-  (the "License"); you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at http://www.mozilla.org/MPL/
-  Software distributed under the License is distributed on an "AS IS" basis,
-  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
-  specific language governing rights and limitations under the License.
-  
-  The Original Code is "ID.java".  Description:
-  "This class contains functionality used by the ID class
-  in the version 2.3.0, 2.3.1, 2.4, and 2.5 packages"
-  
-  The Initial Developer of the Original Code is University Health Network. Copyright (C)
-  2005.  All Rights Reserved.
-  
-  Contributor(s): ______________________________________.
-  
-  Alternatively, the contents of this file may be used under the terms of the
-  GNU General Public License (the "GPL"), in which case the provisions of the GPL are
-  applicable instead of those above.  If you wish to allow use of your version of this
-  file only under the terms of the GPL and not to allow others to use your version
-  of this file under the MPL, indicate your decision by deleting  the provisions above
-  and replace  them with the notice and other provisions required by the GPL License.
-  If you do not delete the provisions above, a recipient may use your version of
-  this file under either the MPL or the GPL.
+	The contents of this file are subject to the Mozilla Public License Version 1.1
+	(the "License"); you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.mozilla.org/MPL/
+	Software distributed under the License is distributed on an "AS IS" basis,
+	WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+	specific language governing rights and limitations under the License.
+	
+	The Original Code is "ID.java".  Description:
+	"This class contains functionality used by the ID class
+	in the version 2.3.0, 2.3.1, 2.4, and 2.5 packages"
+	
+	The Initial Developer of the Original Code is University Health Network. Copyright (C)
+	2005.  All Rights Reserved.
+	
+	Contributor(s): ______________________________________.
+	
+	Alternatively, the contents of this file may be used under the terms of the
+	GNU General Public License (the "GPL"), in which case the provisions of the GPL are
+	applicable instead of those above.  If you wish to allow use of your version of this
+	file only under the terms of the GPL and not to allow others to use your version
+	of this file under the MPL, indicate your decision by deleting  the provisions above
+	and replace  them with the notice and other provisions required by the GPL License.
+	If you do not delete the provisions above, a recipient may use your version of
+	this file under either the MPL or the GPL.
 */
 
 namespace NHapi.Base.Model.Primitive
@@ -60,34 +60,32 @@ namespace NHapi.Base.Model.Primitive
 
 		private int myTable = 0;
 
-		/// <param name="theMessage">message to which this Type belongs
-		/// </param>
-		public ID(IMessage theMessage)
+		/// <summary>Construct the type</summary>
+		/// <param name="theMessage">message to which this Type belongs</param>
+		protected ID(IMessage theMessage)
 			: base(theMessage)
 		{
 		}
 
-
-		public ID(IMessage theMessage, string description)
+		///<summary>Construct the type</summary>
+		///<param name="theMessage">message to which this Type belongs</param>
+		///<param name="description">The description of this type</param>
+		protected ID(IMessage theMessage, string description)
 			: base(theMessage, description)
 		{
 		}
 
-		/// <param name="theMessage">message to which this Type belongs
-		/// </param>
-		/// <param name="theTable">HL7 table from which values are to be drawn 
-		/// </param>
-		public ID(IMessage theMessage, int theTable)
+		/// <param name="theMessage">message to which this Type belongs</param>
+		/// <param name="theTable">HL7 table from which values are to be drawn</param>
+		protected ID(IMessage theMessage, int theTable)
 			: base(theMessage)
 		{
 			myTable = theTable;
 		}
 
-		/// <param name="theMessage">message to which this Type belongs
-		/// </param>
-		/// <param name="theTable">HL7 table from which values are to be drawn 
-		/// </param>
-		public ID(IMessage message, int theTable, string description)
+		/// <param name="theMessage">message to which this Type belongs</param>
+		/// <param name="theTable">HL7 table from which values are to be drawn</param>
+		protected ID(IMessage message, int theTable, string description)
 			: base(message, description)
 		{
 			myTable = theTable;

--- a/src/NHapi.Base/Model/Primitive/IS.cs
+++ b/src/NHapi.Base/Model/Primitive/IS.cs
@@ -1,28 +1,28 @@
 /*
-  The contents of this file are subject to the Mozilla Public License Version 1.1
-  (the "License"); you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at http://www.mozilla.org/MPL/
-  Software distributed under the License is distributed on an "AS IS" basis,
-  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
-  specific language governing rights and limitations under the License.
-  
-  The Original Code is "IS.java".  Description:
-  "This class contains functionality used by the ID class
-  in the version 2.3.0, 2.3.1, 2.4, and 2.5 packages"
-  
-  The Initial Developer of the Original Code is University Health Network. Copyright (C)
-  2005.  All Rights Reserved.
-  
-  Contributor(s): ______________________________________.
-  
-  Alternatively, the contents of this file may be used under the terms of the
-  GNU General Public License (the "GPL"), in which case the provisions of the GPL are
-  applicable instead of those above.  If you wish to allow use of your version of this
-  file only under the terms of the GPL and not to allow others to use your version
-  of this file under the MPL, indicate your decision by deleting  the provisions above
-  and replace  them with the notice and other provisions required by the GPL License.
-  If you do not delete the provisions above, a recipient may use your version of
-  this file under either the MPL or the GPL.
+	The contents of this file are subject to the Mozilla Public License Version 1.1
+	(the "License"); you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.mozilla.org/MPL/
+	Software distributed under the License is distributed on an "AS IS" basis,
+	WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+	specific language governing rights and limitations under the License.
+
+	The Original Code is "IS.java".  Description:
+	"This class contains functionality used by the ID class
+	in the version 2.3.0, 2.3.1, 2.4, and 2.5 packages"
+
+	The Initial Developer of the Original Code is University Health Network. Copyright (C)
+	2005.  All Rights Reserved.
+
+	Contributor(s): ______________________________________.
+
+	Alternatively, the contents of this file may be used under the terms of the
+	GNU General Public License (the "GPL"), in which case the provisions of the GPL are
+	applicable instead of those above.  If you wish to allow use of your version of this
+	file only under the terms of the GPL and not to allow others to use your version
+	of this file under the MPL, indicate your decision by deleting  the provisions above
+	and replace  them with the notice and other provisions required by the GPL License.
+	If you do not delete the provisions above, a recipient may use your version of
+	this file under either the MPL or the GPL.
 */
 
 namespace NHapi.Base.Model.Primitive
@@ -62,15 +62,17 @@ namespace NHapi.Base.Model.Primitive
 
 		private int myTable = 0;
 
-		/// <param name="theMessage">message to which this Type belongs
-		/// </param>
-		public IS(IMessage theMessage)
+		/// <summary>Construct the type</summary>
+		/// <param name="theMessage">message to which this Type belongs</param>
+		protected IS(IMessage theMessage)
 			: base(theMessage)
 		{
 		}
 
-
-		public IS(IMessage theMessage, string description)
+		/// <summary>Construct the type</summary>
+		/// <param name="theMessage">message to which this Type belongs</param>
+		/// <param name="description">The description of this type</param>
+		protected IS(IMessage theMessage, string description)
 			: base(theMessage, description)
 		{
 		}
@@ -79,7 +81,7 @@ namespace NHapi.Base.Model.Primitive
 		/// </param>
 		/// <param name="theTable">HL7 table from which values are to be drawn 
 		/// </param>
-		public IS(IMessage theMessage, int theTable)
+		protected IS(IMessage theMessage, int theTable)
 			: base(theMessage)
 		{
 			myTable = theTable;
@@ -89,7 +91,7 @@ namespace NHapi.Base.Model.Primitive
 		/// </param>
 		/// <param name="theTable">HL7 table from which values are to be drawn 
 		/// </param>
-		public IS(IMessage theMessage, int theTable, string description)
+		protected IS(IMessage theMessage, int theTable, string description)
 			: base(theMessage, description)
 		{
 			myTable = theTable;

--- a/src/NHapi.Base/Model/Primitive/TM.cs
+++ b/src/NHapi.Base/Model/Primitive/TM.cs
@@ -1,27 +1,27 @@
 /*
-  The contents of this file are subject to the Mozilla Public License Version 1.1
-  (the "License"); you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at http://www.mozilla.org/MPL/
-  Software distributed under the License is distributed on an "AS IS" basis,
-  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
-  specific language governing rights and limitations under the License.
-  
-  The Original Code is "TM.java".  Description:
-  "Represents an HL7 TM (time) datatype."
-  
-  The Initial Developer of the Original Code is University Health Network. Copyright (C)
-  2005.  All Rights Reserved.
-  
-  Contributor(s): ______________________________________.
-  
-  Alternatively, the contents of this file may be used under the terms of the
-  GNU General Public License (the "GPL"), in which case the provisions of the GPL are
-  applicable instead of those above.  If you wish to allow use of your version of this
-  file only under the terms of the GPL and not to allow others to use your version
-  of this file under the MPL, indicate your decision by deleting  the provisions above
-  and replace  them with the notice and other provisions required by the GPL License.
-  If you do not delete the provisions above, a recipient may use your version of
-  this file under either the MPL or the GPL.
+	The contents of this file are subject to the Mozilla Public License Version 1.1
+	(the "License"); you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.mozilla.org/MPL/
+	Software distributed under the License is distributed on an "AS IS" basis,
+	WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+	specific language governing rights and limitations under the License.
+	
+	The Original Code is "TM.java".  Description:
+	"Represents an HL7 TM (time) datatype."
+	
+	The Initial Developer of the Original Code is University Health Network. Copyright (C)
+	2005.  All Rights Reserved.
+	
+	Contributor(s): ______________________________________.
+	
+	Alternatively, the contents of this file may be used under the terms of the
+	GNU General Public License (the "GPL"), in which case the provisions of the GPL are
+	applicable instead of those above.  If you wish to allow use of your version of this
+	file only under the terms of the GPL and not to allow others to use your version
+	of this file under the MPL, indicate your decision by deleting  the provisions above
+	and replace  them with the notice and other provisions required by the GPL License.
+	If you do not delete the provisions above, a recipient may use your version of
+	this file under either the MPL or the GPL.
 */
 
 using System;
@@ -51,9 +51,9 @@ namespace NHapi.Base.Model.Primitive
 			}
 		}
 
-		/// <seealso cref="AbstractPrimitive.getValue">
+		/// <seealso cref="AbstractPrimitive.get_Value">
 		/// </seealso>
-		/// <seealso cref="AbstractPrimitive.setValue(java.lang.String)">
+		/// <seealso cref="AbstractPrimitive.set_Value(String)">
 		/// </seealso>
 		/// <throws>  DataTypeException if the value is incorrectly formatted and either validation is  </throws>
 		/// <summary>      enabled for this primitive or detail setters / getters have been called, forcing further
@@ -84,7 +84,7 @@ namespace NHapi.Base.Model.Primitive
 			}
 		}
 
-		/// <seealso cref="CommonTM.setHourPrecision(int)">
+		/// <seealso cref="CommonTM.set_HourPrecision(int)">
 		/// </seealso>
 		/// <throws>  DataTypeException if the value is incorrectly formatted.  If validation is enabled, this  </throws>
 		/// <summary>      exception should be thrown at setValue(), but if not, detailed parsing may be deferred until 
@@ -95,7 +95,7 @@ namespace NHapi.Base.Model.Primitive
 			set { Detail.HourPrecision = value; }
 		}
 
-		/// <seealso cref="CommonTM.setOffset(int)">
+		/// <seealso cref="CommonTM.set_Offset(int)">
 		/// </seealso>
 		/// <throws>  DataTypeException if the value is incorrectly formatted.  If validation is enabled, this  </throws>
 		/// <summary>      exception should be thrown at setValue(), but if not, detailed parsing may be deferred until 
@@ -160,13 +160,15 @@ namespace NHapi.Base.Model.Primitive
 
 		/// <param name="theMessage">message to which this Type belongs
 		/// </param>
-		public TM(IMessage theMessage)
+		protected TM(IMessage theMessage)
 			: base(theMessage)
 		{
 		}
 
-
-		public TM(IMessage theMessage, string description)
+		/// <summary>Construct the type</summary>
+		/// <param name="theMessage">message to which this Type belongs</param>
+		/// <param name="description">The description of this type</param>
+		protected TM(IMessage theMessage, string description)
 			: base(theMessage, description)
 		{
 		}

--- a/src/NHapi.Model.V21/Datatype/CM.cs
+++ b/src/NHapi.Model.V21/Datatype/CM.cs
@@ -1,24 +1,26 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
-using NHapi.Base.Model.Primitive;
 using NHapi.Base.Model;
 
 namespace NHapi.Model.V21.Datatype
 {
-    /// <summary>
-    /// Composite message
-    /// </summary>
-    public class CM : GenericComposite
-    {
+	/// <summary>
+	/// Composite message
+	/// </summary>
+	public class CM : GenericComposite
+	{
 
-        /// <summary>
-        /// Composite message
-        /// </summary>
-        /// <param name="message"></param>
-        public CM(IMessage message)
-            : base(message)
-        {
-        }
-    }
+		/// <summary>Construct the type</summary>
+		/// <param name="theMessage">message to which this Type belongs</param>
+		public CM(IMessage theMessage)
+			: base(theMessage)
+		{
+		}
+
+		/// <summary>Construct the type</summary>
+		/// <param name="theMessage">message to which this Type belongs</param>
+		/// <param name="description">The description of this type</param>
+		public CM(IMessage theMessage, string description)
+			: base(theMessage, description)
+		{
+		}
+	}
 }

--- a/src/NHapi.Model.V21/Datatype/DT.cs
+++ b/src/NHapi.Model.V21/Datatype/DT.cs
@@ -3,36 +3,36 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V21.Datatype
 {
-/// <summary>/// Summary description for DT.
-/// </summary>
-public class DT: NHapi.Base.Model.Primitive.DT
-{
-/// <summary>Return the version
-/// <returns>2.1</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for DT.
+   /// </summary>
+   public class DT : NHapi.Base.Model.Primitive.DT
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.1</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.1";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.1";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public DT(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///</summary>
-                public DT(IMessage theMessage):base(theMessage)
-                {}
-                
-
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public DT(IMessage message, string description) : base(message,description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public DT(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V21/Datatype/ID.cs
+++ b/src/NHapi.Model.V21/Datatype/ID.cs
@@ -3,38 +3,53 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V21.Datatype
 {
-/// <summary>/// Summary description for ID.
-/// </summary>
-public class ID: NHapi.Base.Model.Primitive.ID
-{
-/// <summary>Return the version
-/// <returns>2.1</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for ID.
+   /// </summary>
+   public class ID : NHapi.Base.Model.Primitive.ID
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.1</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.1";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.1";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public ID(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public ID(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///</summary>
-                public ID(IMessage theMessage,int theTable):base(theMessage, theTable)
-                {}
-                
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  public ID(IMessage theMessage, int theTable)
+		  : base(theMessage, theTable)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public ID(IMessage message, int theTable, string description) : base(message,theTable, description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public ID(IMessage theMessage, int theTable, string description)
+		  : base(theMessage, theTable, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V21/Datatype/IS.cs
+++ b/src/NHapi.Model.V21/Datatype/IS.cs
@@ -3,38 +3,54 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V21.Datatype
 {
-/// <summary>/// Summary description for IS.
-/// </summary>
-public class IS: NHapi.Base.Model.Primitive.IS
-{
-/// <summary>Return the version
-/// <returns>2.1</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for IS.
+   /// </summary>
+   public class IS : NHapi.Base.Model.Primitive.IS
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.1</returns>
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.1";
-			    }
-		    }
-            
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.1";
+		 }
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public IS(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///</summary>
-                public IS(IMessage theMessage,int theTable):base(theMessage, theTable)
-                {}
-                
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public IS(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  public IS(IMessage theMessage, int theTable)
+	  		: base(theMessage, theTable)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public IS(IMessage message, int theTable, string description) : base(message,theTable, description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="message">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public IS(IMessage message, int theTable, string description)
+	  		: base(message, theTable, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V21/Datatype/TM.cs
+++ b/src/NHapi.Model.V21/Datatype/TM.cs
@@ -3,36 +3,36 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V21.Datatype
 {
-/// <summary>/// Summary description for TM.
-/// </summary>
-public class TM: NHapi.Base.Model.Primitive.TM
-{
-/// <summary>Return the version
-/// <returns>2.1</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for TM.
+   /// </summary>
+   public class TM : NHapi.Base.Model.Primitive.TM
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.1</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.1";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.1";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public TM(IMessage theMessage)
+	  		: base(theMessage)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///</summary>
-                public TM(IMessage theMessage):base(theMessage)
-                {}
-                
-
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public TM(IMessage message, string description) : base(message,description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public TM(IMessage theMessage, string description)
+	  		: base(theMessage, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V21/Segment/OBX.cs
+++ b/src/NHapi.Model.V21/Segment/OBX.cs
@@ -43,7 +43,7 @@ public class OBX : AbstractSegment  {
        this.add(typeof(ID), false, 1, 2, new System.Object[]{message, 125}, "VALUE TYPE");
        this.add(typeof(CE), true, 1, 80, new System.Object[]{message}, "OBSERVATION IDENTIFIER");
        this.add(typeof(NM), false, 1, 20, new System.Object[]{message}, "OBSERVATION SUB-ID");
-       this.add(typeof(ST), true, 1, 65, new System.Object[]{message}, "OBSERVATION RESULTS");
+       this.add(typeof(Varies), true, 1, 65, new System.Object[]{message}, "OBSERVATION RESULTS");
        this.add(typeof(ID), false, 1, 20, new System.Object[]{message, 0}, "UNITS");
        this.add(typeof(ST), false, 1, 60, new System.Object[]{message}, "REFERENCES RANGE");
        this.add(typeof(ST), false, 5, 10, new System.Object[]{message}, "ABNORMAL FLAGS");
@@ -151,25 +151,29 @@ public class OBX : AbstractSegment  {
 	///<summary>
 	/// Returns OBSERVATION RESULTS(OBX-5).
 	///</summary>
-	public ST OBSERVATIONRESULTS
+	public Varies OBSERVATIONRESULTS
 	{
-		get{
-			ST ret = null;
-			try
+			get
 			{
-			IType t = this.GetField(5, 0);
-				ret = (ST)t;
+				Varies ret = null;
+				try
+				{
+					IType t = this.GetField(5, 0);
+					ret = (Varies)t;
+				}
+				catch (HL7Exception he)
+				{
+					HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+					throw new System.Exception("An unexpected error ocurred", he);
+				}
+				catch (System.Exception ex)
+				{
+					HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
+					throw new System.Exception("An unexpected error ocurred", ex);
+				}
+				return ret;
 			}
-			 catch (HL7Exception he) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
-				throw new System.Exception("An unexpected error ocurred", he);
-		} catch (System.Exception ex) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
-				throw new System.Exception("An unexpected error ocurred", ex);
-    }
-			return ret;
-	}
-  }
+		}
 
 	///<summary>
 	/// Returns UNITS(OBX-6).

--- a/src/NHapi.Model.V22/Datatype/DT.cs
+++ b/src/NHapi.Model.V22/Datatype/DT.cs
@@ -3,36 +3,36 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V22.Datatype
 {
-/// <summary>/// Summary description for DT.
-/// </summary>
-public class DT: NHapi.Base.Model.Primitive.DT
-{
-/// <summary>Return the version
-/// <returns>2.2</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for DT.
+   /// </summary>
+   public class DT : NHapi.Base.Model.Primitive.DT
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.2</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.2";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.2";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public DT(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///</summary>
-                public DT(IMessage theMessage):base(theMessage)
-                {}
-                
-
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public DT(IMessage message, string description) : base(message,description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public DT(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V22/Datatype/ID.cs
+++ b/src/NHapi.Model.V22/Datatype/ID.cs
@@ -3,38 +3,53 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V22.Datatype
 {
-/// <summary>/// Summary description for ID.
-/// </summary>
-public class ID: NHapi.Base.Model.Primitive.ID
-{
-/// <summary>Return the version
-/// <returns>2.2</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for ID.
+   /// </summary>
+   public class ID : NHapi.Base.Model.Primitive.ID
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.2</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.2";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.2";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public ID(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public ID(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///</summary>
-                public ID(IMessage theMessage,int theTable):base(theMessage, theTable)
-                {}
-                
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  public ID(IMessage theMessage, int theTable)
+		  : base(theMessage, theTable)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public ID(IMessage message, int theTable, string description) : base(message,theTable, description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public ID(IMessage theMessage, int theTable, string description)
+		  : base(theMessage, theTable, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V22/Datatype/IS.cs
+++ b/src/NHapi.Model.V22/Datatype/IS.cs
@@ -3,38 +3,54 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V22.Datatype
 {
-/// <summary>/// Summary description for IS.
-/// </summary>
-public class IS: NHapi.Base.Model.Primitive.IS
-{
-/// <summary>Return the version
-/// <returns>2.2</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for IS.
+   /// </summary>
+   public class IS : NHapi.Base.Model.Primitive.IS
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.2</returns>
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.2";
-			    }
-		    }
-            
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.2";
+		 }
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public IS(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///</summary>
-                public IS(IMessage theMessage,int theTable):base(theMessage, theTable)
-                {}
-                
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public IS(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  public IS(IMessage theMessage, int theTable)
+	  		: base(theMessage, theTable)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public IS(IMessage message, int theTable, string description) : base(message,theTable, description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="message">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public IS(IMessage message, int theTable, string description)
+	  		: base(message, theTable, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V22/Datatype/TM.cs
+++ b/src/NHapi.Model.V22/Datatype/TM.cs
@@ -3,36 +3,36 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V22.Datatype
 {
-/// <summary>/// Summary description for TM.
-/// </summary>
-public class TM: NHapi.Base.Model.Primitive.TM
-{
-/// <summary>Return the version
-/// <returns>2.2</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for TM.
+   /// </summary>
+   public class TM : NHapi.Base.Model.Primitive.TM
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.2</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.2";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.2";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public TM(IMessage theMessage)
+	  		: base(theMessage)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///</summary>
-                public TM(IMessage theMessage):base(theMessage)
-                {}
-                
-
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public TM(IMessage message, string description) : base(message,description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public TM(IMessage theMessage, string description)
+	  		: base(theMessage, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V23/Datatype/DT.cs
+++ b/src/NHapi.Model.V23/Datatype/DT.cs
@@ -3,36 +3,36 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V23.Datatype
 {
-/// <summary>/// Summary description for DT.
-/// </summary>
-public class DT: NHapi.Base.Model.Primitive.DT
-{
-/// <summary>Return the version
-/// <returns>2.3</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for DT.
+   /// </summary>
+   public class DT : NHapi.Base.Model.Primitive.DT
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.3</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.3";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.3";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public DT(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///</summary>
-                public DT(IMessage theMessage):base(theMessage)
-                {}
-                
-
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public DT(IMessage message, string description) : base(message,description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public DT(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V23/Datatype/ID.cs
+++ b/src/NHapi.Model.V23/Datatype/ID.cs
@@ -3,38 +3,53 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V23.Datatype
 {
-/// <summary>/// Summary description for ID.
-/// </summary>
-public class ID: NHapi.Base.Model.Primitive.ID
-{
-/// <summary>Return the version
-/// <returns>2.3</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for ID.
+   /// </summary>
+   public class ID : NHapi.Base.Model.Primitive.ID
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.3</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.3";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.3";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public ID(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public ID(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///</summary>
-                public ID(IMessage theMessage,int theTable):base(theMessage, theTable)
-                {}
-                
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  public ID(IMessage theMessage, int theTable)
+		  : base(theMessage, theTable)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public ID(IMessage message, int theTable, string description) : base(message,theTable, description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public ID(IMessage theMessage, int theTable, string description)
+		  : base(theMessage, theTable, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V23/Datatype/IS.cs
+++ b/src/NHapi.Model.V23/Datatype/IS.cs
@@ -3,38 +3,54 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V23.Datatype
 {
-/// <summary>/// Summary description for IS.
-/// </summary>
-public class IS: NHapi.Base.Model.Primitive.IS
-{
-/// <summary>Return the version
-/// <returns>2.3</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for IS.
+   /// </summary>
+   public class IS : NHapi.Base.Model.Primitive.IS
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.3</returns>
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.3";
-			    }
-		    }
-            
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.3";
+		 }
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public IS(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///</summary>
-                public IS(IMessage theMessage,int theTable):base(theMessage, theTable)
-                {}
-                
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public IS(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  public IS(IMessage theMessage, int theTable)
+	  		: base(theMessage, theTable)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public IS(IMessage message, int theTable, string description) : base(message,theTable, description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="message">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public IS(IMessage message, int theTable, string description)
+	  		: base(message, theTable, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V23/Datatype/TM.cs
+++ b/src/NHapi.Model.V23/Datatype/TM.cs
@@ -3,36 +3,36 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V23.Datatype
 {
-/// <summary>/// Summary description for TM.
-/// </summary>
-public class TM: NHapi.Base.Model.Primitive.TM
-{
-/// <summary>Return the version
-/// <returns>2.3</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for TM.
+   /// </summary>
+   public class TM : NHapi.Base.Model.Primitive.TM
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.3</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.3";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.3";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public TM(IMessage theMessage)
+	  		: base(theMessage)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///</summary>
-                public TM(IMessage theMessage):base(theMessage)
-                {}
-                
-
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public TM(IMessage message, string description) : base(message,description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public TM(IMessage theMessage, string description)
+	  		: base(theMessage, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V231/Datatype/DT.cs
+++ b/src/NHapi.Model.V231/Datatype/DT.cs
@@ -3,36 +3,36 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V231.Datatype
 {
-/// <summary>/// Summary description for DT.
-/// </summary>
-public class DT: NHapi.Base.Model.Primitive.DT
-{
-/// <summary>Return the version
-/// <returns>2.3.1</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for DT.
+   /// </summary>
+   public class DT : NHapi.Base.Model.Primitive.DT
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.3.1</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.3.1";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.3.1";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public DT(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///</summary>
-                public DT(IMessage theMessage):base(theMessage)
-                {}
-                
-
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public DT(IMessage message, string description) : base(message,description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public DT(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V231/Datatype/ID.cs
+++ b/src/NHapi.Model.V231/Datatype/ID.cs
@@ -3,38 +3,53 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V231.Datatype
 {
-/// <summary>/// Summary description for ID.
-/// </summary>
-public class ID: NHapi.Base.Model.Primitive.ID
-{
-/// <summary>Return the version
-/// <returns>2.3.1</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for ID.
+   /// </summary>
+   public class ID : NHapi.Base.Model.Primitive.ID
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.3.1</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.3.1";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.3.1";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public ID(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public ID(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///</summary>
-                public ID(IMessage theMessage,int theTable):base(theMessage, theTable)
-                {}
-                
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  public ID(IMessage theMessage, int theTable)
+		  : base(theMessage, theTable)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public ID(IMessage message, int theTable, string description) : base(message,theTable, description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public ID(IMessage theMessage, int theTable, string description)
+		  : base(theMessage, theTable, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V231/Datatype/IS.cs
+++ b/src/NHapi.Model.V231/Datatype/IS.cs
@@ -3,38 +3,54 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V231.Datatype
 {
-/// <summary>/// Summary description for IS.
-/// </summary>
-public class IS: NHapi.Base.Model.Primitive.IS
-{
-/// <summary>Return the version
-/// <returns>2.3.1</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for IS.
+   /// </summary>
+   public class IS : NHapi.Base.Model.Primitive.IS
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.3.1</returns>
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.3.1";
-			    }
-		    }
-            
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.3.1";
+		 }
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public IS(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///</summary>
-                public IS(IMessage theMessage,int theTable):base(theMessage, theTable)
-                {}
-                
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public IS(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  public IS(IMessage theMessage, int theTable)
+	  		: base(theMessage, theTable)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public IS(IMessage message, int theTable, string description) : base(message,theTable, description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="message">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public IS(IMessage message, int theTable, string description)
+	  		: base(message, theTable, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V231/Datatype/TM.cs
+++ b/src/NHapi.Model.V231/Datatype/TM.cs
@@ -3,36 +3,36 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V231.Datatype
 {
-/// <summary>/// Summary description for TM.
-/// </summary>
-public class TM: NHapi.Base.Model.Primitive.TM
-{
-/// <summary>Return the version
-/// <returns>2.3.1</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for TM.
+   /// </summary>
+   public class TM : NHapi.Base.Model.Primitive.TM
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.3.1</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.3.1";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.3.1";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public TM(IMessage theMessage)
+	  		: base(theMessage)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///</summary>
-                public TM(IMessage theMessage):base(theMessage)
-                {}
-                
-
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public TM(IMessage message, string description) : base(message,description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public TM(IMessage theMessage, string description)
+	  		: base(theMessage, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V24/Datatype/DT.cs
+++ b/src/NHapi.Model.V24/Datatype/DT.cs
@@ -3,36 +3,36 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V24.Datatype
 {
-/// <summary>/// Summary description for DT.
-/// </summary>
-public class DT: NHapi.Base.Model.Primitive.DT
-{
-/// <summary>Return the version
-/// <returns>2.4</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for DT.
+   /// </summary>
+   public class DT : NHapi.Base.Model.Primitive.DT
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.4</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.4";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.4";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public DT(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///</summary>
-                public DT(IMessage theMessage):base(theMessage)
-                {}
-                
-
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public DT(IMessage message, string description) : base(message,description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public DT(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V24/Datatype/ID.cs
+++ b/src/NHapi.Model.V24/Datatype/ID.cs
@@ -3,38 +3,53 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V24.Datatype
 {
-/// <summary>/// Summary description for ID.
-/// </summary>
-public class ID: NHapi.Base.Model.Primitive.ID
-{
-/// <summary>Return the version
-/// <returns>2.4</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for ID.
+   /// </summary>
+   public class ID : NHapi.Base.Model.Primitive.ID
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.4</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.4";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.4";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public ID(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public ID(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///</summary>
-                public ID(IMessage theMessage,int theTable):base(theMessage, theTable)
-                {}
-                
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  public ID(IMessage theMessage, int theTable)
+		  : base(theMessage, theTable)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public ID(IMessage message, int theTable, string description) : base(message,theTable, description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public ID(IMessage theMessage, int theTable, string description)
+		  : base(theMessage, theTable, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V24/Datatype/IS.cs
+++ b/src/NHapi.Model.V24/Datatype/IS.cs
@@ -3,38 +3,54 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V24.Datatype
 {
-/// <summary>/// Summary description for IS.
-/// </summary>
-public class IS: NHapi.Base.Model.Primitive.IS
-{
-/// <summary>Return the version
-/// <returns>2.4</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for IS.
+   /// </summary>
+   public class IS : NHapi.Base.Model.Primitive.IS
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.4</returns>
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.4";
-			    }
-		    }
-            
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.4";
+		 }
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public IS(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///</summary>
-                public IS(IMessage theMessage,int theTable):base(theMessage, theTable)
-                {}
-                
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public IS(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  public IS(IMessage theMessage, int theTable)
+	  		: base(theMessage, theTable)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public IS(IMessage message, int theTable, string description) : base(message,theTable, description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="message">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public IS(IMessage message, int theTable, string description)
+	  		: base(message, theTable, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V24/Datatype/TM.cs
+++ b/src/NHapi.Model.V24/Datatype/TM.cs
@@ -3,36 +3,36 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V24.Datatype
 {
-/// <summary>/// Summary description for TM.
-/// </summary>
-public class TM: NHapi.Base.Model.Primitive.TM
-{
-/// <summary>Return the version
-/// <returns>2.4</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for TM.
+   /// </summary>
+   public class TM : NHapi.Base.Model.Primitive.TM
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.4</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.4";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.4";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public TM(IMessage theMessage)
+	  		: base(theMessage)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///</summary>
-                public TM(IMessage theMessage):base(theMessage)
-                {}
-                
-
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public TM(IMessage message, string description) : base(message,description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public TM(IMessage theMessage, string description)
+	  		: base(theMessage, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V25/Datatype/DT.cs
+++ b/src/NHapi.Model.V25/Datatype/DT.cs
@@ -3,36 +3,36 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V25.Datatype
 {
-/// <summary>/// Summary description for DT.
-/// </summary>
-public class DT: NHapi.Base.Model.Primitive.DT
-{
-/// <summary>Return the version
-/// <returns>2.5</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for DT.
+   /// </summary>
+   public class DT : NHapi.Base.Model.Primitive.DT
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.5</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.5";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.5";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public DT(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///</summary>
-                public DT(IMessage theMessage):base(theMessage)
-                {}
-                
-
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public DT(IMessage message, string description) : base(message,description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public DT(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V25/Datatype/ID.cs
+++ b/src/NHapi.Model.V25/Datatype/ID.cs
@@ -3,38 +3,53 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V25.Datatype
 {
-/// <summary>/// Summary description for ID.
-/// </summary>
-public class ID: NHapi.Base.Model.Primitive.ID
-{
-/// <summary>Return the version
-/// <returns>2.5</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for ID.
+   /// </summary>
+   public class ID : NHapi.Base.Model.Primitive.ID
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.5</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.5";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.5";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public ID(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public ID(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///</summary>
-                public ID(IMessage theMessage,int theTable):base(theMessage, theTable)
-                {}
-                
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  public ID(IMessage theMessage, int theTable)
+		  : base(theMessage, theTable)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public ID(IMessage message, int theTable, string description) : base(message,theTable, description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public ID(IMessage theMessage, int theTable, string description)
+		  : base(theMessage, theTable, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V25/Datatype/IS.cs
+++ b/src/NHapi.Model.V25/Datatype/IS.cs
@@ -3,38 +3,54 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V25.Datatype
 {
-/// <summary>/// Summary description for IS.
-/// </summary>
-public class IS: NHapi.Base.Model.Primitive.IS
-{
-/// <summary>Return the version
-/// <returns>2.5</returns>
-///</summary>
+   /// <summary>
+	/// Summary description for IS.
+   /// </summary>
+   public class IS : NHapi.Base.Model.Primitive.IS
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.5</returns>
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.5";
-			    }
-		    }
-            
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.5";
+		 }
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public IS(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///</summary>
-                public IS(IMessage theMessage,int theTable):base(theMessage, theTable)
-                {}
-                
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public IS(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  public IS(IMessage theMessage, int theTable)
+	  		: base(theMessage, theTable)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public IS(IMessage message, int theTable, string description) : base(message,theTable, description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="message">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public IS(IMessage message, int theTable, string description)
+	  		: base(message, theTable, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V25/Datatype/TM.cs
+++ b/src/NHapi.Model.V25/Datatype/TM.cs
@@ -3,36 +3,36 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V25.Datatype
 {
-/// <summary>/// Summary description for TM.
-/// </summary>
-public class TM: NHapi.Base.Model.Primitive.TM
-{
-/// <summary>Return the version
-/// <returns>2.5</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for TM.
+   /// </summary>
+   public class TM : NHapi.Base.Model.Primitive.TM
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.5</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.5";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.5";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public TM(IMessage theMessage)
+	  		: base(theMessage)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///</summary>
-                public TM(IMessage theMessage):base(theMessage)
-                {}
-                
-
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public TM(IMessage message, string description) : base(message,description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public TM(IMessage theMessage, string description)
+	  		: base(theMessage, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V251/Datatype/DT.cs
+++ b/src/NHapi.Model.V251/Datatype/DT.cs
@@ -3,36 +3,36 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V251.Datatype
 {
-/// <summary>/// Summary description for DT.
-/// </summary>
-public class DT: NHapi.Base.Model.Primitive.DT
-{
-/// <summary>Return the version
-/// <returns>2.5.1</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for DT.
+   /// </summary>
+   public class DT : NHapi.Base.Model.Primitive.DT
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.5.1</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.5.1";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.5.1";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public DT(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///</summary>
-                public DT(IMessage theMessage):base(theMessage)
-                {}
-                
-
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public DT(IMessage message, string description) : base(message,description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public DT(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V251/Datatype/DTM.cs
+++ b/src/NHapi.Model.V251/Datatype/DTM.cs
@@ -3,68 +3,75 @@ using NHapi.Base.Model.Primitive;
 
 namespace NHapi.Model.V251.Datatype
 {
-	/// <summary>
-	/// Note: The class description below has been excerpted from the Hl7 2.4 documentation. Sectional
-	/// references made below also refer to the same documentation.
-	/// Format: YYYY[MM[DD[HHMM[SS[.S[S[S[S]]]]]]]][+/-ZZZZ]^&lt;degree of precision&gt;
-	/// Contains the exact time of an event, including the date and time. The date portion of a time stamp follows the rules of a
-	/// date field and the time portion follows the rules of a time field. The time zone (+/-ZZZZ) is represented as +/-HHMM
-	/// offset from UTC (formerly Greenwich Mean Time (GMT)), where +0000 or -0000 both represent UTC (without offset).
-	/// The specific data representations used in the HL7 encoding rules are compatible with ISO 8824-1987(E).
-	/// In prior versions of HL7, an optional second component indicates the degree of precision of the time stamp (Y = year, L
-	/// = month, D = day, H = hour, M = minute, S = second). This optional second component is retained only for purposes of
-	/// backward compatibility.
-	/// 
-	/// By site-specific agreement, YYYYMMDD[HHMM[SS[.S[S[S[S]]]]]][+/-ZZZZ]^&lt;degree of precision&gt; may be used
-	/// where backward compatibility must be maintained.
-	/// In the current and future versions of HL7, the precision is indicated by limiting the number of digits used, unless the
-	/// optional second component is present. Thus, YYYY is used to specify a precision of "year," YYYYMM specifies a
-	/// precision of "month," YYYYMMDD specifies a precision of "day," YYYYMMDDHH is used to specify a precision of
-	/// "hour," YYYYMMDDHHMM is used to specify a precision of "minute," YYYYMMDDHHMMSS is used to specify a
-	/// precision of seconds, and YYYYMMDDHHMMSS.SSSS is used to specify a precision of ten thousandths of a second.
-	/// In each of these cases, the time zone is an optional component. Note that if the time zone is not included, the timezone
-	/// defaults to that of the local time zone of the sender. Also note that a TS valued field with the HHMM part set to "0000"
-	/// represents midnight of the night extending from the previous day to the day given by the YYYYMMDD part (see example
-	/// below). Maximum length of the time stamp is 26. 
-	/// 
-	/// Examples:
-	/// |19760704010159-0500|
-	/// 1:01:59 on July 4, 1976 in the Eastern Standard Time zone (USA).
-	/// |19760704010159-0400|
-	/// 1:01:59 on July 4, 1976 in the Eastern Daylight Saving Time zone (USA).
-	/// |198807050000|
-	/// Midnight of the night extending from July 4 to July 5, 1988 in the local time zone of the sender.
-	/// |19880705|
-	/// Same as prior example, but precision extends only to the day. Could be used for a birthdate, if the time of birth is
-	/// unknown.
-	/// |19981004010159+0100|
-	/// 1:01:59 on October 4, 1998 in Amsterdam, NL. (Time zone=+0100).
-	/// The HL7 Standard strongly recommends that all systems routinely send the time zone offset but does not require it. All
-	/// HL7 systems are required to accept the time zone offset, but its implementation is application specific. For many
-	/// applications the time of interest is the local time of the sender. For example, an application in the Eastern Standard Time
-	/// zone receiving notification of an admission that takes place at 11:00 PM in San Francisco on December 11 would prefer
-	/// to treat the admission as having occurred on December 11 rather than advancing the date to December 12.
-	/// Note: The time zone [+/-ZZZZ], when used, is restricted to legally-defined time zones and is represented in HHMM
-	/// format.
-	/// One exception to this rule would be a clinical system that processed patient data collected in a clinic and a nearby hospital
-	/// that happens to be in a different time zone. Such applications may choose to convert the data to a common
-	/// representation. Similar concerns apply to the transitions to and from daylight saving time. HL7 supports such requirements
-	/// by requiring that the time zone information be present when the information is sent. It does not, however, specify which of
-	/// the treatments discussed here will be applied by the receiving system.
-	/// </summary>
-	public class DTM : TSComponentOne
-	{
-		public DTM(IMessage theMessage) : base(theMessage)
-		{
-		}
+   /// <summary>
+   /// Note: The class description below has been excerpted from the Hl7 2.4 documentation. Sectional
+   /// references made below also refer to the same documentation.
+   /// Format: YYYY[MM[DD[HHMM[SS[.S[S[S[S]]]]]]]][+/-ZZZZ]^&lt;degree of precision&gt;
+   /// Contains the exact time of an event, including the date and time. The date portion of a time stamp follows the rules of a
+   /// date field and the time portion follows the rules of a time field. The time zone (+/-ZZZZ) is represented as +/-HHMM
+   /// offset from UTC (formerly Greenwich Mean Time (GMT)), where +0000 or -0000 both represent UTC (without offset).
+   /// The specific data representations used in the HL7 encoding rules are compatible with ISO 8824-1987(E).
+   /// In prior versions of HL7, an optional second component indicates the degree of precision of the time stamp (Y = year, L
+   /// = month, D = day, H = hour, M = minute, S = second). This optional second component is retained only for purposes of
+   /// backward compatibility.
+   /// 
+   /// By site-specific agreement, YYYYMMDD[HHMM[SS[.S[S[S[S]]]]]][+/-ZZZZ]^&lt;degree of precision&gt; may be used
+   /// where backward compatibility must be maintained.
+   /// In the current and future versions of HL7, the precision is indicated by limiting the number of digits used, unless the
+   /// optional second component is present. Thus, YYYY is used to specify a precision of "year," YYYYMM specifies a
+   /// precision of "month," YYYYMMDD specifies a precision of "day," YYYYMMDDHH is used to specify a precision of
+   /// "hour," YYYYMMDDHHMM is used to specify a precision of "minute," YYYYMMDDHHMMSS is used to specify a
+   /// precision of seconds, and YYYYMMDDHHMMSS.SSSS is used to specify a precision of ten thousandths of a second.
+   /// In each of these cases, the time zone is an optional component. Note that if the time zone is not included, the timezone
+   /// defaults to that of the local time zone of the sender. Also note that a TS valued field with the HHMM part set to "0000"
+   /// represents midnight of the night extending from the previous day to the day given by the YYYYMMDD part (see example
+   /// below). Maximum length of the time stamp is 26. 
+   /// 
+   /// Examples:
+   /// |19760704010159-0500|
+   /// 1:01:59 on July 4, 1976 in the Eastern Standard Time zone (USA).
+   /// |19760704010159-0400|
+   /// 1:01:59 on July 4, 1976 in the Eastern Daylight Saving Time zone (USA).
+   /// |198807050000|
+   /// Midnight of the night extending from July 4 to July 5, 1988 in the local time zone of the sender.
+   /// |19880705|
+   /// Same as prior example, but precision extends only to the day. Could be used for a birthdate, if the time of birth is
+   /// unknown.
+   /// |19981004010159+0100|
+   /// 1:01:59 on October 4, 1998 in Amsterdam, NL. (Time zone=+0100).
+   /// The HL7 Standard strongly recommends that all systems routinely send the time zone offset but does not require it. All
+   /// HL7 systems are required to accept the time zone offset, but its implementation is application specific. For many
+   /// applications the time of interest is the local time of the sender. For example, an application in the Eastern Standard Time
+   /// zone receiving notification of an admission that takes place at 11:00 PM in San Francisco on December 11 would prefer
+   /// to treat the admission as having occurred on December 11 rather than advancing the date to December 12.
+   /// Note: The time zone [+/-ZZZZ], when used, is restricted to legally-defined time zones and is represented in HHMM
+   /// format.
+   /// One exception to this rule would be a clinical system that processed patient data collected in a clinic and a nearby hospital
+   /// that happens to be in a different time zone. Such applications may choose to convert the data to a common
+   /// representation. Similar concerns apply to the transitions to and from daylight saving time. HL7 supports such requirements
+   /// by requiring that the time zone information be present when the information is sent. It does not, however, specify which of
+   /// the treatments discussed here will be applied by the receiving system.
+   /// </summary>
+   public class DTM : TSComponentOne
+   {
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public DTM(IMessage theMessage)
+	  		: base(theMessage)
+	  {
+	  }
 
-		public DTM(IMessage theMessage, string description) : base(theMessage, description)
-		{
-		}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public DTM(IMessage theMessage, string description)
+	  		: base(theMessage, description)
+	  {
+	  }
 
-		public string getVersion()
-		{
-			return Constants.VERSION;
-		}
-	}
+	  public string getVersion()
+	  {
+		 return Constants.VERSION;
+	  }
+   }
 }

--- a/src/NHapi.Model.V251/Datatype/ID.cs
+++ b/src/NHapi.Model.V251/Datatype/ID.cs
@@ -3,38 +3,53 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V251.Datatype
 {
-/// <summary>/// Summary description for ID.
-/// </summary>
-public class ID: NHapi.Base.Model.Primitive.ID
-{
-/// <summary>Return the version
-/// <returns>2.5.1</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for ID.
+   /// </summary>
+   public class ID : NHapi.Base.Model.Primitive.ID
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.5.1</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.5.1";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.5.1";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public ID(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public ID(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///</summary>
-                public ID(IMessage theMessage,int theTable):base(theMessage, theTable)
-                {}
-                
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  public ID(IMessage theMessage, int theTable)
+		  : base(theMessage, theTable)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public ID(IMessage message, int theTable, string description) : base(message,theTable, description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public ID(IMessage theMessage, int theTable, string description)
+		  : base(theMessage, theTable, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V251/Datatype/IS.cs
+++ b/src/NHapi.Model.V251/Datatype/IS.cs
@@ -3,38 +3,54 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V251.Datatype
 {
-/// <summary>/// Summary description for IS.
-/// </summary>
-public class IS: NHapi.Base.Model.Primitive.IS
-{
-/// <summary>Return the version
-/// <returns>2.5.1</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for IS.
+   /// </summary>
+   public class IS : NHapi.Base.Model.Primitive.IS
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.5.1</returns>
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.5.1";
-			    }
-		    }
-            
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.5.1";
+		 }
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public IS(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///</summary>
-                public IS(IMessage theMessage,int theTable):base(theMessage, theTable)
-                {}
-                
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public IS(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  public IS(IMessage theMessage, int theTable)
+	  		: base(theMessage, theTable)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public IS(IMessage message, int theTable, string description) : base(message,theTable, description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="message">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public IS(IMessage message, int theTable, string description)
+	  		: base(message, theTable, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V251/Datatype/TM.cs
+++ b/src/NHapi.Model.V251/Datatype/TM.cs
@@ -3,36 +3,36 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V251.Datatype
 {
-/// <summary>/// Summary description for TM.
-/// </summary>
-public class TM: NHapi.Base.Model.Primitive.TM
-{
-/// <summary>Return the version
-/// <returns>2.5.1</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for TM.
+   /// </summary>
+   public class TM : NHapi.Base.Model.Primitive.TM
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.5.1</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.5.1";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.5.1";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public TM(IMessage theMessage)
+	  		: base(theMessage)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///</summary>
-                public TM(IMessage theMessage):base(theMessage)
-                {}
-                
-
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public TM(IMessage message, string description) : base(message,description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public TM(IMessage theMessage, string description)
+	  		: base(theMessage, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V26/Datatype/DT.cs
+++ b/src/NHapi.Model.V26/Datatype/DT.cs
@@ -3,36 +3,36 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V26.Datatype
 {
-/// <summary>/// Summary description for DT.
-/// </summary>
-public class DT: NHapi.Base.Model.Primitive.DT
-{
-/// <summary>Return the version
-/// <returns>2.6</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for DT.
+   /// </summary>
+   public class DT : NHapi.Base.Model.Primitive.DT
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.6</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.6";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.6";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public DT(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///</summary>
-                public DT(IMessage theMessage):base(theMessage)
-                {}
-                
-
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public DT(IMessage message, string description) : base(message,description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public DT(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V26/Datatype/DTM.cs
+++ b/src/NHapi.Model.V26/Datatype/DTM.cs
@@ -3,68 +3,76 @@ using NHapi.Base.Model.Primitive;
 
 namespace NHapi.Model.V26.Datatype
 {
-	/// <summary>
-	/// Note: The class description below has been excerpted from the Hl7 2.4 documentation. Sectional
-	/// references made below also refer to the same documentation.
-	/// Format: YYYY[MM[DD[HHMM[SS[.S[S[S[S]]]]]]]][+/-ZZZZ]^&lt;degree of precision&gt;
-	/// Contains the exact time of an event, including the date and time. The date portion of a time stamp follows the rules of a
-	/// date field and the time portion follows the rules of a time field. The time zone (+/-ZZZZ) is represented as +/-HHMM
-	/// offset from UTC (formerly Greenwich Mean Time (GMT)), where +0000 or -0000 both represent UTC (without offset).
-	/// The specific data representations used in the HL7 encoding rules are compatible with ISO 8824-1987(E).
-	/// In prior versions of HL7, an optional second component indicates the degree of precision of the time stamp (Y = year, L
-	/// = month, D = day, H = hour, M = minute, S = second). This optional second component is retained only for purposes of
-	/// backward compatibility.
-	/// 
-	/// By site-specific agreement, YYYYMMDD[HHMM[SS[.S[S[S[S]]]]]][+/-ZZZZ]^&lt;degree of precision&gt; may be used
-	/// where backward compatibility must be maintained.
-	/// In the current and future versions of HL7, the precision is indicated by limiting the number of digits used, unless the
-	/// optional second component is present. Thus, YYYY is used to specify a precision of "year," YYYYMM specifies a
-	/// precision of "month," YYYYMMDD specifies a precision of "day," YYYYMMDDHH is used to specify a precision of
-	/// "hour," YYYYMMDDHHMM is used to specify a precision of "minute," YYYYMMDDHHMMSS is used to specify a
-	/// precision of seconds, and YYYYMMDDHHMMSS.SSSS is used to specify a precision of ten thousandths of a second.
-	/// In each of these cases, the time zone is an optional component. Note that if the time zone is not included, the timezone
-	/// defaults to that of the local time zone of the sender. Also note that a TS valued field with the HHMM part set to "0000"
-	/// represents midnight of the night extending from the previous day to the day given by the YYYYMMDD part (see example
-	/// below). Maximum length of the time stamp is 26. 
-	/// 
-	/// Examples:
-	/// |19760704010159-0500|
-	/// 1:01:59 on July 4, 1976 in the Eastern Standard Time zone (USA).
-	/// |19760704010159-0400|
-	/// 1:01:59 on July 4, 1976 in the Eastern Daylight Saving Time zone (USA).
-	/// |198807050000|
-	/// Midnight of the night extending from July 4 to July 5, 1988 in the local time zone of the sender.
-	/// |19880705|
-	/// Same as prior example, but precision extends only to the day. Could be used for a birthdate, if the time of birth is
-	/// unknown.
-	/// |19981004010159+0100|
-	/// 1:01:59 on October 4, 1998 in Amsterdam, NL. (Time zone=+0100).
-	/// The HL7 Standard strongly recommends that all systems routinely send the time zone offset but does not require it. All
-	/// HL7 systems are required to accept the time zone offset, but its implementation is application specific. For many
-	/// applications the time of interest is the local time of the sender. For example, an application in the Eastern Standard Time
-	/// zone receiving notification of an admission that takes place at 11:00 PM in San Francisco on December 11 would prefer
-	/// to treat the admission as having occurred on December 11 rather than advancing the date to December 12.
-	/// Note: The time zone [+/-ZZZZ], when used, is restricted to legally-defined time zones and is represented in HHMM
-	/// format.
-	/// One exception to this rule would be a clinical system that processed patient data collected in a clinic and a nearby hospital
-	/// that happens to be in a different time zone. Such applications may choose to convert the data to a common
-	/// representation. Similar concerns apply to the transitions to and from daylight saving time. HL7 supports such requirements
-	/// by requiring that the time zone information be present when the information is sent. It does not, however, specify which of
-	/// the treatments discussed here will be applied by the receiving system.
-	/// </summary>
-	public class DTM : TSComponentOne
-	{
-		public DTM(IMessage theMessage) : base(theMessage)
-		{
-		}
+   /// <summary>
+   /// Note: The class description below has been excerpted from the Hl7 2.4 documentation. Sectional
+   /// references made below also refer to the same documentation.
+   /// Format: YYYY[MM[DD[HHMM[SS[.S[S[S[S]]]]]]]][+/-ZZZZ]^&lt;degree of precision&gt;
+   /// Contains the exact time of an event, including the date and time. The date portion of a time stamp follows the rules of a
+   /// date field and the time portion follows the rules of a time field. The time zone (+/-ZZZZ) is represented as +/-HHMM
+   /// offset from UTC (formerly Greenwich Mean Time (GMT)), where +0000 or -0000 both represent UTC (without offset).
+   /// The specific data representations used in the HL7 encoding rules are compatible with ISO 8824-1987(E).
+   /// In prior versions of HL7, an optional second component indicates the degree of precision of the time stamp (Y = year, L
+   /// = month, D = day, H = hour, M = minute, S = second). This optional second component is retained only for purposes of
+   /// backward compatibility.
+   /// 
+   /// By site-specific agreement, YYYYMMDD[HHMM[SS[.S[S[S[S]]]]]][+/-ZZZZ]^&lt;degree of precision&gt; may be used
+   /// where backward compatibility must be maintained.
+   /// In the current and future versions of HL7, the precision is indicated by limiting the number of digits used, unless the
+   /// optional second component is present. Thus, YYYY is used to specify a precision of "year," YYYYMM specifies a
+   /// precision of "month," YYYYMMDD specifies a precision of "day," YYYYMMDDHH is used to specify a precision of
+   /// "hour," YYYYMMDDHHMM is used to specify a precision of "minute," YYYYMMDDHHMMSS is used to specify a
+   /// precision of seconds, and YYYYMMDDHHMMSS.SSSS is used to specify a precision of ten thousandths of a second.
+   /// In each of these cases, the time zone is an optional component. Note that if the time zone is not included, the timezone
+   /// defaults to that of the local time zone of the sender. Also note that a TS valued field with the HHMM part set to "0000"
+   /// represents midnight of the night extending from the previous day to the day given by the YYYYMMDD part (see example
+   /// below). Maximum length of the time stamp is 26. 
+   /// <example>
+   /// Examples:
+   /// |19760704010159-0500|
+   /// 1:01:59 on July 4, 1976 in the Eastern Standard Time zone (USA).
+   /// |19760704010159-0400|
+   /// 1:01:59 on July 4, 1976 in the Eastern Daylight Saving Time zone (USA).
+   /// |198807050000|
+   /// Midnight of the night extending from July 4 to July 5, 1988 in the local time zone of the sender.
+   /// |19880705|
+   /// Same as prior example, but precision extends only to the day. Could be used for a birthdate, if the time of birth is
+   /// unknown.
+   /// |19981004010159+0100|
+   /// 1:01:59 on October 4, 1998 in Amsterdam, NL. (Time zone=+0100).
+   /// </example>
+   /// The HL7 Standard strongly recommends that all systems routinely send the time zone offset but does not require it. All
+   /// HL7 systems are required to accept the time zone offset, but its implementation is application specific. For many
+   /// applications the time of interest is the local time of the sender. For example, an application in the Eastern Standard Time
+   /// zone receiving notification of an admission that takes place at 11:00 PM in San Francisco on December 11 would prefer
+   /// to treat the admission as having occurred on December 11 rather than advancing the date to December 12.
+   /// Note: The time zone [+/-ZZZZ], when used, is restricted to legally-defined time zones and is represented in HHMM
+   /// format.
+   /// One exception to this rule would be a clinical system that processed patient data collected in a clinic and a nearby hospital
+   /// that happens to be in a different time zone. Such applications may choose to convert the data to a common
+   /// representation. Similar concerns apply to the transitions to and from daylight saving time. HL7 supports such requirements
+   /// by requiring that the time zone information be present when the information is sent. It does not, however, specify which of
+   /// the treatments discussed here will be applied by the receiving system.
+   /// </summary>
+   public class DTM : TSComponentOne
+   {
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public DTM(IMessage theMessage)
+	  		: base(theMessage)
+	  {
+	  }
 
-		public DTM(IMessage theMessage, string description) : base(theMessage, description)
-		{
-		}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public DTM(IMessage theMessage, string description)
+	  		: base(theMessage, description)
+	  {
+	  }
 
-		public string getVersion()
-		{
-			return Constants.VERSION;
-		}
-	}
+	  public string getVersion()
+	  {
+		 return Constants.VERSION;
+	  }
+   }
 }

--- a/src/NHapi.Model.V26/Datatype/ID.cs
+++ b/src/NHapi.Model.V26/Datatype/ID.cs
@@ -3,38 +3,53 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V26.Datatype
 {
-/// <summary>/// Summary description for ID.
-/// </summary>
-public class ID: NHapi.Base.Model.Primitive.ID
-{
-/// <summary>Return the version
-/// <returns>2.6</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for ID.
+   /// </summary>
+   public class ID : NHapi.Base.Model.Primitive.ID
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.6</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.6";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.6";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public ID(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public ID(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///</summary>
-                public ID(IMessage theMessage,int theTable):base(theMessage, theTable)
-                {}
-                
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  public ID(IMessage theMessage, int theTable)
+		  : base(theMessage, theTable)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public ID(IMessage message, int theTable, string description) : base(message,theTable, description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public ID(IMessage theMessage, int theTable, string description)
+		  : base(theMessage, theTable, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V26/Datatype/IS.cs
+++ b/src/NHapi.Model.V26/Datatype/IS.cs
@@ -3,38 +3,54 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V26.Datatype
 {
-/// <summary>/// Summary description for IS.
-/// </summary>
-public class IS: NHapi.Base.Model.Primitive.IS
-{
-/// <summary>Return the version
-/// <returns>2.6</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for IS.
+   /// </summary>
+   public class IS : NHapi.Base.Model.Primitive.IS
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.6</returns>
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.6";
-			    }
-		    }
-            
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.6";
+		 }
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public IS(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///</summary>
-                public IS(IMessage theMessage,int theTable):base(theMessage, theTable)
-                {}
-                
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public IS(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  public IS(IMessage theMessage, int theTable)
+	  		: base(theMessage, theTable)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public IS(IMessage message, int theTable, string description) : base(message,theTable, description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="message">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public IS(IMessage message, int theTable, string description)
+	  		: base(message, theTable, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V26/Datatype/TM.cs
+++ b/src/NHapi.Model.V26/Datatype/TM.cs
@@ -3,36 +3,36 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V26.Datatype
 {
-/// <summary>/// Summary description for TM.
-/// </summary>
-public class TM: NHapi.Base.Model.Primitive.TM
-{
-/// <summary>Return the version
-/// <returns>2.6</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for TM.
+   /// </summary>
+   public class TM : NHapi.Base.Model.Primitive.TM
+   {
+	  /// <value>
+	  /// Return the version
+	  ///</value>
+	  /// <returns>2.6</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.6";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.6";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public TM(IMessage theMessage)
+	  		: base(theMessage)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///</summary>
-                public TM(IMessage theMessage):base(theMessage)
-                {}
-                
-
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public TM(IMessage message, string description) : base(message,description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public TM(IMessage theMessage, string description)
+	  		: base(theMessage, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V27/Datatype/DT.cs
+++ b/src/NHapi.Model.V27/Datatype/DT.cs
@@ -3,36 +3,36 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V27.Datatype
 {
-/// <summary>/// Summary description for DT.
-/// </summary>
-public class DT: NHapi.Base.Model.Primitive.DT
-{
-/// <summary>Return the version
-/// <returns>2.7</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for DT.
+   /// </summary>
+   public class DT : NHapi.Base.Model.Primitive.DT
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.7</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.7";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.7";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public DT(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///</summary>
-                public DT(IMessage theMessage):base(theMessage)
-                {}
-                
-
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public DT(IMessage message, string description) : base(message,description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public DT(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V27/Datatype/DTM.cs
+++ b/src/NHapi.Model.V27/Datatype/DTM.cs
@@ -3,68 +3,75 @@ using NHapi.Base.Model.Primitive;
 
 namespace NHapi.Model.V27.Datatype
 {
-	/// <summary>
-	/// Note: The class description below has been excerpted from the Hl7 2.4 documentation. Sectional
-	/// references made below also refer to the same documentation.
-	/// Format: YYYY[MM[DD[HHMM[SS[.S[S[S[S]]]]]]]][+/-ZZZZ]^&lt;degree of precision&gt;
-	/// Contains the exact time of an event, including the date and time. The date portion of a time stamp follows the rules of a
-	/// date field and the time portion follows the rules of a time field. The time zone (+/-ZZZZ) is represented as +/-HHMM
-	/// offset from UTC (formerly Greenwich Mean Time (GMT)), where +0000 or -0000 both represent UTC (without offset).
-	/// The specific data representations used in the HL7 encoding rules are compatible with ISO 8824-1987(E).
-	/// In prior versions of HL7, an optional second component indicates the degree of precision of the time stamp (Y = year, L
-	/// = month, D = day, H = hour, M = minute, S = second). This optional second component is retained only for purposes of
-	/// backward compatibility.
-	/// 
-	/// By site-specific agreement, YYYYMMDD[HHMM[SS[.S[S[S[S]]]]]][+/-ZZZZ]^&lt;degree of precision&gt; may be used
-	/// where backward compatibility must be maintained.
-	/// In the current and future versions of HL7, the precision is indicated by limiting the number of digits used, unless the
-	/// optional second component is present. Thus, YYYY is used to specify a precision of "year," YYYYMM specifies a
-	/// precision of "month," YYYYMMDD specifies a precision of "day," YYYYMMDDHH is used to specify a precision of
-	/// "hour," YYYYMMDDHHMM is used to specify a precision of "minute," YYYYMMDDHHMMSS is used to specify a
-	/// precision of seconds, and YYYYMMDDHHMMSS.SSSS is used to specify a precision of ten thousandths of a second.
-	/// In each of these cases, the time zone is an optional component. Note that if the time zone is not included, the timezone
-	/// defaults to that of the local time zone of the sender. Also note that a TS valued field with the HHMM part set to "0000"
-	/// represents midnight of the night extending from the previous day to the day given by the YYYYMMDD part (see example
-	/// below). Maximum length of the time stamp is 26. 
-	/// 
-	/// Examples:
-	/// |19760704010159-0500|
-	/// 1:01:59 on July 4, 1976 in the Eastern Standard Time zone (USA).
-	/// |19760704010159-0400|
-	/// 1:01:59 on July 4, 1976 in the Eastern Daylight Saving Time zone (USA).
-	/// |198807050000|
-	/// Midnight of the night extending from July 4 to July 5, 1988 in the local time zone of the sender.
-	/// |19880705|
-	/// Same as prior example, but precision extends only to the day. Could be used for a birthdate, if the time of birth is
-	/// unknown.
-	/// |19981004010159+0100|
-	/// 1:01:59 on October 4, 1998 in Amsterdam, NL. (Time zone=+0100).
-	/// The HL7 Standard strongly recommends that all systems routinely send the time zone offset but does not require it. All
-	/// HL7 systems are required to accept the time zone offset, but its implementation is application specific. For many
-	/// applications the time of interest is the local time of the sender. For example, an application in the Eastern Standard Time
-	/// zone receiving notification of an admission that takes place at 11:00 PM in San Francisco on December 11 would prefer
-	/// to treat the admission as having occurred on December 11 rather than advancing the date to December 12.
-	/// Note: The time zone [+/-ZZZZ], when used, is restricted to legally-defined time zones and is represented in HHMM
-	/// format.
-	/// One exception to this rule would be a clinical system that processed patient data collected in a clinic and a nearby hospital
-	/// that happens to be in a different time zone. Such applications may choose to convert the data to a common
-	/// representation. Similar concerns apply to the transitions to and from daylight saving time. HL7 supports such requirements
-	/// by requiring that the time zone information be present when the information is sent. It does not, however, specify which of
-	/// the treatments discussed here will be applied by the receiving system.
-	/// </summary>
-	public class DTM : TSComponentOne
-	{
-		public DTM(IMessage theMessage) : base(theMessage)
-		{
-		}
+   /// <summary>
+   /// Note: The class description below has been excerpted from the Hl7 2.4 documentation. Sectional
+   /// references made below also refer to the same documentation.
+   /// Format: YYYY[MM[DD[HHMM[SS[.S[S[S[S]]]]]]]][+/-ZZZZ]^&lt;degree of precision&gt;
+   /// Contains the exact time of an event, including the date and time. The date portion of a time stamp follows the rules of a
+   /// date field and the time portion follows the rules of a time field. The time zone (+/-ZZZZ) is represented as +/-HHMM
+   /// offset from UTC (formerly Greenwich Mean Time (GMT)), where +0000 or -0000 both represent UTC (without offset).
+   /// The specific data representations used in the HL7 encoding rules are compatible with ISO 8824-1987(E).
+   /// In prior versions of HL7, an optional second component indicates the degree of precision of the time stamp (Y = year, L
+   /// = month, D = day, H = hour, M = minute, S = second). This optional second component is retained only for purposes of
+   /// backward compatibility.
+   /// 
+   /// By site-specific agreement, YYYYMMDD[HHMM[SS[.S[S[S[S]]]]]][+/-ZZZZ]^&lt;degree of precision&gt; may be used
+   /// where backward compatibility must be maintained.
+   /// In the current and future versions of HL7, the precision is indicated by limiting the number of digits used, unless the
+   /// optional second component is present. Thus, YYYY is used to specify a precision of "year," YYYYMM specifies a
+   /// precision of "month," YYYYMMDD specifies a precision of "day," YYYYMMDDHH is used to specify a precision of
+   /// "hour," YYYYMMDDHHMM is used to specify a precision of "minute," YYYYMMDDHHMMSS is used to specify a
+   /// precision of seconds, and YYYYMMDDHHMMSS.SSSS is used to specify a precision of ten thousandths of a second.
+   /// In each of these cases, the time zone is an optional component. Note that if the time zone is not included, the timezone
+   /// defaults to that of the local time zone of the sender. Also note that a TS valued field with the HHMM part set to "0000"
+   /// represents midnight of the night extending from the previous day to the day given by the YYYYMMDD part (see example
+   /// below). Maximum length of the time stamp is 26. 
+   /// 
+   /// Examples:
+   /// |19760704010159-0500|
+   /// 1:01:59 on July 4, 1976 in the Eastern Standard Time zone (USA).
+   /// |19760704010159-0400|
+   /// 1:01:59 on July 4, 1976 in the Eastern Daylight Saving Time zone (USA).
+   /// |198807050000|
+   /// Midnight of the night extending from July 4 to July 5, 1988 in the local time zone of the sender.
+   /// |19880705|
+   /// Same as prior example, but precision extends only to the day. Could be used for a birthdate, if the time of birth is
+   /// unknown.
+   /// |19981004010159+0100|
+   /// 1:01:59 on October 4, 1998 in Amsterdam, NL. (Time zone=+0100).
+   /// The HL7 Standard strongly recommends that all systems routinely send the time zone offset but does not require it. All
+   /// HL7 systems are required to accept the time zone offset, but its implementation is application specific. For many
+   /// applications the time of interest is the local time of the sender. For example, an application in the Eastern Standard Time
+   /// zone receiving notification of an admission that takes place at 11:00 PM in San Francisco on December 11 would prefer
+   /// to treat the admission as having occurred on December 11 rather than advancing the date to December 12.
+   /// Note: The time zone [+/-ZZZZ], when used, is restricted to legally-defined time zones and is represented in HHMM
+   /// format.
+   /// One exception to this rule would be a clinical system that processed patient data collected in a clinic and a nearby hospital
+   /// that happens to be in a different time zone. Such applications may choose to convert the data to a common
+   /// representation. Similar concerns apply to the transitions to and from daylight saving time. HL7 supports such requirements
+   /// by requiring that the time zone information be present when the information is sent. It does not, however, specify which of
+   /// the treatments discussed here will be applied by the receiving system.
+   /// </summary>
+   public class DTM : TSComponentOne
+   {
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public DTM(IMessage theMessage)
+	  		: base(theMessage)
+	  {
+	  }
 
-		public DTM(IMessage theMessage, string description) : base(theMessage, description)
-		{
-		}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public DTM(IMessage theMessage, string description)
+	  		: base(theMessage, description)
+	  {
+	  }
 
-		public string getVersion()
-		{
-			return Constants.VERSION;
-		}
-	}
+	  public string getVersion()
+	  {
+		 return Constants.VERSION;
+	  }
+   }
 }

--- a/src/NHapi.Model.V27/Datatype/ID.cs
+++ b/src/NHapi.Model.V27/Datatype/ID.cs
@@ -3,38 +3,53 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V27.Datatype
 {
-/// <summary>/// Summary description for ID.
-/// </summary>
-public class ID: NHapi.Base.Model.Primitive.ID
-{
-/// <summary>Return the version
-/// <returns>2.7</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for ID.
+   /// </summary>
+   public class ID : NHapi.Base.Model.Primitive.ID
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.7</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.7";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.7";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public ID(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public ID(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///</summary>
-                public ID(IMessage theMessage,int theTable):base(theMessage, theTable)
-                {}
-                
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  public ID(IMessage theMessage, int theTable)
+		  : base(theMessage, theTable)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public ID(IMessage message, int theTable, string description) : base(message,theTable, description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public ID(IMessage theMessage, int theTable, string description)
+		  : base(theMessage, theTable, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V27/Datatype/IS.cs
+++ b/src/NHapi.Model.V27/Datatype/IS.cs
@@ -3,38 +3,54 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V27.Datatype
 {
-/// <summary>/// Summary description for IS.
-/// </summary>
-public class IS: NHapi.Base.Model.Primitive.IS
-{
-/// <summary>Return the version
-/// <returns>2.7</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for IS.
+   /// </summary>
+   public class IS : NHapi.Base.Model.Primitive.IS
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.7</returns>
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.7";
-			    }
-		    }
-            
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.7";
+		 }
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public IS(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///</summary>
-                public IS(IMessage theMessage,int theTable):base(theMessage, theTable)
-                {}
-                
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public IS(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  public IS(IMessage theMessage, int theTable)
+	  		: base(theMessage, theTable)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public IS(IMessage message, int theTable, string description) : base(message,theTable, description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="message">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public IS(IMessage message, int theTable, string description)
+	  		: base(message, theTable, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V27/Datatype/TM.cs
+++ b/src/NHapi.Model.V27/Datatype/TM.cs
@@ -3,36 +3,36 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V27.Datatype
 {
-/// <summary>/// Summary description for TM.
-/// </summary>
-public class TM: NHapi.Base.Model.Primitive.TM
-{
-/// <summary>Return the version
-/// <returns>2.7</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for TM.
+   /// </summary>
+   public class TM : NHapi.Base.Model.Primitive.TM
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.7</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.7";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.7";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public TM(IMessage theMessage)
+	  		: base(theMessage)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///</summary>
-                public TM(IMessage theMessage):base(theMessage)
-                {}
-                
-
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public TM(IMessage message, string description) : base(message,description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public TM(IMessage theMessage, string description)
+	  		: base(theMessage, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V271/Datatype/DT.cs
+++ b/src/NHapi.Model.V271/Datatype/DT.cs
@@ -3,36 +3,36 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V271.Datatype
 {
-/// <summary>/// Summary description for DT.
-/// </summary>
-public class DT: NHapi.Base.Model.Primitive.DT
-{
-/// <summary>Return the version
-/// <returns>2.7.1</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for DT.
+   /// </summary>
+   public class DT : NHapi.Base.Model.Primitive.DT
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.7.1</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.7.1";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.7.1";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public DT(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///</summary>
-                public DT(IMessage theMessage):base(theMessage)
-                {}
-                
-
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public DT(IMessage message, string description) : base(message,description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public DT(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V271/Datatype/DTM.cs
+++ b/src/NHapi.Model.V271/Datatype/DTM.cs
@@ -3,68 +3,75 @@ using NHapi.Base.Model.Primitive;
 
 namespace NHapi.Model.V271.Datatype
 {
-	/// <summary>
-	/// Note: The class description below has been excerpted from the Hl7 2.4 documentation. Sectional
-	/// references made below also refer to the same documentation.
-	/// Format: YYYY[MM[DD[HHMM[SS[.S[S[S[S]]]]]]]][+/-ZZZZ]^&lt;degree of precision&gt;
-	/// Contains the exact time of an event, including the date and time. The date portion of a time stamp follows the rules of a
-	/// date field and the time portion follows the rules of a time field. The time zone (+/-ZZZZ) is represented as +/-HHMM
-	/// offset from UTC (formerly Greenwich Mean Time (GMT)), where +0000 or -0000 both represent UTC (without offset).
-	/// The specific data representations used in the HL7 encoding rules are compatible with ISO 8824-1987(E).
-	/// In prior versions of HL7, an optional second component indicates the degree of precision of the time stamp (Y = year, L
-	/// = month, D = day, H = hour, M = minute, S = second). This optional second component is retained only for purposes of
-	/// backward compatibility.
-	/// 
-	/// By site-specific agreement, YYYYMMDD[HHMM[SS[.S[S[S[S]]]]]][+/-ZZZZ]^&lt;degree of precision&gt; may be used
-	/// where backward compatibility must be maintained.
-	/// In the current and future versions of HL7, the precision is indicated by limiting the number of digits used, unless the
-	/// optional second component is present. Thus, YYYY is used to specify a precision of "year," YYYYMM specifies a
-	/// precision of "month," YYYYMMDD specifies a precision of "day," YYYYMMDDHH is used to specify a precision of
-	/// "hour," YYYYMMDDHHMM is used to specify a precision of "minute," YYYYMMDDHHMMSS is used to specify a
-	/// precision of seconds, and YYYYMMDDHHMMSS.SSSS is used to specify a precision of ten thousandths of a second.
-	/// In each of these cases, the time zone is an optional component. Note that if the time zone is not included, the timezone
-	/// defaults to that of the local time zone of the sender. Also note that a TS valued field with the HHMM part set to "0000"
-	/// represents midnight of the night extending from the previous day to the day given by the YYYYMMDD part (see example
-	/// below). Maximum length of the time stamp is 26. 
-	/// 
-	/// Examples:
-	/// |19760704010159-0500|
-	/// 1:01:59 on July 4, 1976 in the Eastern Standard Time zone (USA).
-	/// |19760704010159-0400|
-	/// 1:01:59 on July 4, 1976 in the Eastern Daylight Saving Time zone (USA).
-	/// |198807050000|
-	/// Midnight of the night extending from July 4 to July 5, 1988 in the local time zone of the sender.
-	/// |19880705|
-	/// Same as prior example, but precision extends only to the day. Could be used for a birthdate, if the time of birth is
-	/// unknown.
-	/// |19981004010159+0100|
-	/// 1:01:59 on October 4, 1998 in Amsterdam, NL. (Time zone=+0100).
-	/// The HL7 Standard strongly recommends that all systems routinely send the time zone offset but does not require it. All
-	/// HL7 systems are required to accept the time zone offset, but its implementation is application specific. For many
-	/// applications the time of interest is the local time of the sender. For example, an application in the Eastern Standard Time
-	/// zone receiving notification of an admission that takes place at 11:00 PM in San Francisco on December 11 would prefer
-	/// to treat the admission as having occurred on December 11 rather than advancing the date to December 12.
-	/// Note: The time zone [+/-ZZZZ], when used, is restricted to legally-defined time zones and is represented in HHMM
-	/// format.
-	/// One exception to this rule would be a clinical system that processed patient data collected in a clinic and a nearby hospital
-	/// that happens to be in a different time zone. Such applications may choose to convert the data to a common
-	/// representation. Similar concerns apply to the transitions to and from daylight saving time. HL7 supports such requirements
-	/// by requiring that the time zone information be present when the information is sent. It does not, however, specify which of
-	/// the treatments discussed here will be applied by the receiving system.
-	/// </summary>
-	public class DTM : TSComponentOne
-	{
-		public DTM(IMessage theMessage) : base(theMessage)
-		{
-		}
+   /// <summary>
+   /// Note: The class description below has been excerpted from the Hl7 2.4 documentation. Sectional
+   /// references made below also refer to the same documentation.
+   /// Format: YYYY[MM[DD[HHMM[SS[.S[S[S[S]]]]]]]][+/-ZZZZ]^&lt;degree of precision&gt;
+   /// Contains the exact time of an event, including the date and time. The date portion of a time stamp follows the rules of a
+   /// date field and the time portion follows the rules of a time field. The time zone (+/-ZZZZ) is represented as +/-HHMM
+   /// offset from UTC (formerly Greenwich Mean Time (GMT)), where +0000 or -0000 both represent UTC (without offset).
+   /// The specific data representations used in the HL7 encoding rules are compatible with ISO 8824-1987(E).
+   /// In prior versions of HL7, an optional second component indicates the degree of precision of the time stamp (Y = year, L
+   /// = month, D = day, H = hour, M = minute, S = second). This optional second component is retained only for purposes of
+   /// backward compatibility.
+   /// 
+   /// By site-specific agreement, YYYYMMDD[HHMM[SS[.S[S[S[S]]]]]][+/-ZZZZ]^&lt;degree of precision&gt; may be used
+   /// where backward compatibility must be maintained.
+   /// In the current and future versions of HL7, the precision is indicated by limiting the number of digits used, unless the
+   /// optional second component is present. Thus, YYYY is used to specify a precision of "year," YYYYMM specifies a
+   /// precision of "month," YYYYMMDD specifies a precision of "day," YYYYMMDDHH is used to specify a precision of
+   /// "hour," YYYYMMDDHHMM is used to specify a precision of "minute," YYYYMMDDHHMMSS is used to specify a
+   /// precision of seconds, and YYYYMMDDHHMMSS.SSSS is used to specify a precision of ten thousandths of a second.
+   /// In each of these cases, the time zone is an optional component. Note that if the time zone is not included, the timezone
+   /// defaults to that of the local time zone of the sender. Also note that a TS valued field with the HHMM part set to "0000"
+   /// represents midnight of the night extending from the previous day to the day given by the YYYYMMDD part (see example
+   /// below). Maximum length of the time stamp is 26. 
+   /// 
+   /// Examples:
+   /// |19760704010159-0500|
+   /// 1:01:59 on July 4, 1976 in the Eastern Standard Time zone (USA).
+   /// |19760704010159-0400|
+   /// 1:01:59 on July 4, 1976 in the Eastern Daylight Saving Time zone (USA).
+   /// |198807050000|
+   /// Midnight of the night extending from July 4 to July 5, 1988 in the local time zone of the sender.
+   /// |19880705|
+   /// Same as prior example, but precision extends only to the day. Could be used for a birthdate, if the time of birth is
+   /// unknown.
+   /// |19981004010159+0100|
+   /// 1:01:59 on October 4, 1998 in Amsterdam, NL. (Time zone=+0100).
+   /// The HL7 Standard strongly recommends that all systems routinely send the time zone offset but does not require it. All
+   /// HL7 systems are required to accept the time zone offset, but its implementation is application specific. For many
+   /// applications the time of interest is the local time of the sender. For example, an application in the Eastern Standard Time
+   /// zone receiving notification of an admission that takes place at 11:00 PM in San Francisco on December 11 would prefer
+   /// to treat the admission as having occurred on December 11 rather than advancing the date to December 12.
+   /// Note: The time zone [+/-ZZZZ], when used, is restricted to legally-defined time zones and is represented in HHMM
+   /// format.
+   /// One exception to this rule would be a clinical system that processed patient data collected in a clinic and a nearby hospital
+   /// that happens to be in a different time zone. Such applications may choose to convert the data to a common
+   /// representation. Similar concerns apply to the transitions to and from daylight saving time. HL7 supports such requirements
+   /// by requiring that the time zone information be present when the information is sent. It does not, however, specify which of
+   /// the treatments discussed here will be applied by the receiving system.
+   /// </summary>
+   public class DTM : TSComponentOne
+   {
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public DTM(IMessage theMessage)
+	  		: base(theMessage)
+	  {
+	  }
 
-		public DTM(IMessage theMessage, string description) : base(theMessage, description)
-		{
-		}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public DTM(IMessage theMessage, string description)
+	  		: base(theMessage, description)
+	  {
+	  }
 
-		public string getVersion()
-		{
-			return Constants.VERSION;
-		}
-	}
+	  public string getVersion()
+	  {
+		 return Constants.VERSION;
+	  }
+   }
 }

--- a/src/NHapi.Model.V271/Datatype/ID.cs
+++ b/src/NHapi.Model.V271/Datatype/ID.cs
@@ -3,38 +3,53 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V271.Datatype
 {
-/// <summary>/// Summary description for ID.
-/// </summary>
-public class ID: NHapi.Base.Model.Primitive.ID
-{
-/// <summary>Return the version
-/// <returns>2.7.1</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for ID.
+   /// </summary>
+   public class ID : NHapi.Base.Model.Primitive.ID
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.7.1</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.7.1";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.7.1";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public ID(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public ID(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///</summary>
-                public ID(IMessage theMessage,int theTable):base(theMessage, theTable)
-                {}
-                
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  public ID(IMessage theMessage, int theTable)
+		  : base(theMessage, theTable)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public ID(IMessage message, int theTable, string description) : base(message,theTable, description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public ID(IMessage theMessage, int theTable, string description)
+		  : base(theMessage, theTable, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V271/Datatype/IS.cs
+++ b/src/NHapi.Model.V271/Datatype/IS.cs
@@ -3,38 +3,54 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V271.Datatype
 {
-/// <summary>/// Summary description for IS.
-/// </summary>
-public class IS: NHapi.Base.Model.Primitive.IS
-{
-/// <summary>Return the version
-/// <returns>2.7.1</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for IS.
+   /// </summary>
+   public class IS : NHapi.Base.Model.Primitive.IS
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.7.1</returns>
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.7.1";
-			    }
-		    }
-            
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.7.1";
+		 }
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public IS(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///</summary>
-                public IS(IMessage theMessage,int theTable):base(theMessage, theTable)
-                {}
-                
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public IS(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  public IS(IMessage theMessage, int theTable)
+	  		: base(theMessage, theTable)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public IS(IMessage message, int theTable, string description) : base(message,theTable, description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="message">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public IS(IMessage message, int theTable, string description)
+	  		: base(message, theTable, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V271/Datatype/TM.cs
+++ b/src/NHapi.Model.V271/Datatype/TM.cs
@@ -3,36 +3,36 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V271.Datatype
 {
-/// <summary>/// Summary description for TM.
-/// </summary>
-public class TM: NHapi.Base.Model.Primitive.TM
-{
-/// <summary>Return the version
-/// <returns>2.7.1</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for TM.
+   /// </summary>
+   public class TM : NHapi.Base.Model.Primitive.TM
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.7.1</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.7.1";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.7.1";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public TM(IMessage theMessage)
+	  		: base(theMessage)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///</summary>
-                public TM(IMessage theMessage):base(theMessage)
-                {}
-                
-
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public TM(IMessage message, string description) : base(message,description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public TM(IMessage theMessage, string description)
+	  		: base(theMessage, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V271/Datatype/XAD.cs
+++ b/src/NHapi.Model.V271/Datatype/XAD.cs
@@ -20,7 +20,7 @@ namespace NHapi.Model.V271.Datatype
 /// <li>County/Parish Code (CWE)</li>
 /// <li>Census Tract (CWE)</li>
 /// <li>Address Representation Code (ID)</li>
-/// <li>Address Validity Range (XAD)</li>
+/// <li>Address Validity Range (ST)</li>
 /// <li>Effective Date (DTM)</li>
 /// <li>Expiration Date (DTM)</li>
 /// <li>Expiration Reason (CWE)</li>
@@ -62,7 +62,7 @@ public class XAD : AbstractType, IComposite{
 		data[8] = new CWE(message,"County/Parish Code");
 		data[9] = new CWE(message,"Census Tract");
 		data[10] = new ID(message, 465,"Address Representation Code");
-		data[11] = new XAD(message,"Address Validity Range");
+		data[11] = new ST(message,"Address Validity Range");
 		data[12] = new DTM(message,"Effective Date");
 		data[13] = new DTM(message,"Expiration Date");
 		data[14] = new CWE(message,"Expiration Reason");
@@ -293,11 +293,11 @@ get{
 	/// Returns Address Validity Range (component #11).  This is a convenience method that saves you from 
 	/// casting and handling an exception.
 	///</summary>
-	public XAD AddressValidityRange {
+	public ST AddressValidityRange {
 get{
-	   XAD ret = null;
+	   ST ret = null;
 	   try {
-	      ret = (XAD)this[11];
+	      ret = (ST)this[11];
 	   } catch (DataTypeException e) {
 	      HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem accessing known data type component - this is a bug.", e);
 	      throw new System.Exception("An unexpected error ocurred",e);

--- a/src/NHapi.Model.V271/Datatype/XON.cs
+++ b/src/NHapi.Model.V271/Datatype/XON.cs
@@ -11,7 +11,7 @@ namespace NHapi.Model.V271.Datatype
 /// <p>The HL7 XON (Extended Composite Name and Identification Number for Organizations) data type.  Consists of the following components: </p><ol>
 /// <li>Organization Name (ST)</li>
 /// <li>Organization Name Type Code (CWE)</li>
-/// <li>ID Number (XON)</li>
+/// <li>ID Number (ST)</li>
 /// <li>Identifier Check Digit (NM)</li>
 /// <li>Check Digit Scheme (ID)</li>
 /// <li>Assigning Authority (HD)</li>
@@ -40,7 +40,7 @@ public class XON : AbstractType, IComposite{
 		data = new IType[10];
 		data[0] = new ST(message,"Organization Name");
 		data[1] = new CWE(message,"Organization Name Type Code");
-		data[2] = new XON(message,"ID Number");
+		data[2] = new ST(message,"ID Number");
 		data[3] = new NM(message,"Identifier Check Digit");
 		data[4] = new ID(message, 61,"Check Digit Scheme");
 		data[5] = new HD(message,"Assigning Authority");
@@ -114,11 +114,11 @@ get{
 	/// Returns ID Number (component #2).  This is a convenience method that saves you from 
 	/// casting and handling an exception.
 	///</summary>
-	public XON IDNumber {
+	public ST IDNumber {
 get{
-	   XON ret = null;
+	   ST ret = null;
 	   try {
-	      ret = (XON)this[2];
+	      ret = (ST)this[2];
 	   } catch (DataTypeException e) {
 	      HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem accessing known data type component - this is a bug.", e);
 	      throw new System.Exception("An unexpected error ocurred",e);

--- a/src/NHapi.Model.V271/Datatype/XTN.cs
+++ b/src/NHapi.Model.V271/Datatype/XTN.cs
@@ -9,7 +9,7 @@ namespace NHapi.Model.V271.Datatype
 
 ///<summary>
 /// <p>The HL7 XTN (Extended Telecommunication Number) data type.  Consists of the following components: </p><ol>
-/// <li>Telephone Number (XTN)</li>
+/// <li>Telephone Number (ST)</li>
 /// <li>Telecommunication Use Code (ID)</li>
 /// <li>Telecommunication Equipment Type (ID)</li>
 /// <li>Communication Address (ST)</li>
@@ -46,7 +46,7 @@ public class XTN : AbstractType, IComposite{
 	///</summary>
 	public XTN(IMessage message, string description) : base(message, description){
 		data = new IType[18];
-		data[0] = new XTN(message,"Telephone Number");
+		data[0] = new ST(message,"Telephone Number");
 		data[1] = new ID(message, 201,"Telecommunication Use Code");
 		data[2] = new ID(message, 202,"Telecommunication Equipment Type");
 		data[3] = new ST(message,"Communication Address");
@@ -96,11 +96,11 @@ get{
 	/// Returns Telephone Number (component #0).  This is a convenience method that saves you from 
 	/// casting and handling an exception.
 	///</summary>
-	public XTN TelephoneNumber {
+	public ST TelephoneNumber {
 get{
-	   XTN ret = null;
+	   ST ret = null;
 	   try {
-	      ret = (XTN)this[0];
+	      ret = (ST)this[0];
 	   } catch (DataTypeException e) {
 	      HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem accessing known data type component - this is a bug.", e);
 	      throw new System.Exception("An unexpected error ocurred",e);

--- a/src/NHapi.Model.V28/Datatype/DT.cs
+++ b/src/NHapi.Model.V28/Datatype/DT.cs
@@ -3,36 +3,36 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V28.Datatype
 {
-/// <summary>/// Summary description for DT.
-/// </summary>
-public class DT: NHapi.Base.Model.Primitive.DT
-{
-/// <summary>Return the version
-/// <returns>2.8</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for DT.
+   /// </summary>
+   public class DT : NHapi.Base.Model.Primitive.DT
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.8</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.8";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.8";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public DT(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///</summary>
-                public DT(IMessage theMessage):base(theMessage)
-                {}
-                
-
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public DT(IMessage message, string description) : base(message,description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public DT(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V28/Datatype/DTM.cs
+++ b/src/NHapi.Model.V28/Datatype/DTM.cs
@@ -3,68 +3,75 @@ using NHapi.Base.Model.Primitive;
 
 namespace NHapi.Model.V28.Datatype
 {
-	/// <summary>
-	/// Note: The class description below has been excerpted from the Hl7 2.4 documentation. Sectional
-	/// references made below also refer to the same documentation.
-	/// Format: YYYY[MM[DD[HHMM[SS[.S[S[S[S]]]]]]]][+/-ZZZZ]^&lt;degree of precision&gt;
-	/// Contains the exact time of an event, including the date and time. The date portion of a time stamp follows the rules of a
-	/// date field and the time portion follows the rules of a time field. The time zone (+/-ZZZZ) is represented as +/-HHMM
-	/// offset from UTC (formerly Greenwich Mean Time (GMT)), where +0000 or -0000 both represent UTC (without offset).
-	/// The specific data representations used in the HL7 encoding rules are compatible with ISO 8824-1987(E).
-	/// In prior versions of HL7, an optional second component indicates the degree of precision of the time stamp (Y = year, L
-	/// = month, D = day, H = hour, M = minute, S = second). This optional second component is retained only for purposes of
-	/// backward compatibility.
-	/// 
-	/// By site-specific agreement, YYYYMMDD[HHMM[SS[.S[S[S[S]]]]]][+/-ZZZZ]^&lt;degree of precision&gt; may be used
-	/// where backward compatibility must be maintained.
-	/// In the current and future versions of HL7, the precision is indicated by limiting the number of digits used, unless the
-	/// optional second component is present. Thus, YYYY is used to specify a precision of "year," YYYYMM specifies a
-	/// precision of "month," YYYYMMDD specifies a precision of "day," YYYYMMDDHH is used to specify a precision of
-	/// "hour," YYYYMMDDHHMM is used to specify a precision of "minute," YYYYMMDDHHMMSS is used to specify a
-	/// precision of seconds, and YYYYMMDDHHMMSS.SSSS is used to specify a precision of ten thousandths of a second.
-	/// In each of these cases, the time zone is an optional component. Note that if the time zone is not included, the timezone
-	/// defaults to that of the local time zone of the sender. Also note that a TS valued field with the HHMM part set to "0000"
-	/// represents midnight of the night extending from the previous day to the day given by the YYYYMMDD part (see example
-	/// below). Maximum length of the time stamp is 26. 
-	/// 
-	/// Examples:
-	/// |19760704010159-0500|
-	/// 1:01:59 on July 4, 1976 in the Eastern Standard Time zone (USA).
-	/// |19760704010159-0400|
-	/// 1:01:59 on July 4, 1976 in the Eastern Daylight Saving Time zone (USA).
-	/// |198807050000|
-	/// Midnight of the night extending from July 4 to July 5, 1988 in the local time zone of the sender.
-	/// |19880705|
-	/// Same as prior example, but precision extends only to the day. Could be used for a birthdate, if the time of birth is
-	/// unknown.
-	/// |19981004010159+0100|
-	/// 1:01:59 on October 4, 1998 in Amsterdam, NL. (Time zone=+0100).
-	/// The HL7 Standard strongly recommends that all systems routinely send the time zone offset but does not require it. All
-	/// HL7 systems are required to accept the time zone offset, but its implementation is application specific. For many
-	/// applications the time of interest is the local time of the sender. For example, an application in the Eastern Standard Time
-	/// zone receiving notification of an admission that takes place at 11:00 PM in San Francisco on December 11 would prefer
-	/// to treat the admission as having occurred on December 11 rather than advancing the date to December 12.
-	/// Note: The time zone [+/-ZZZZ], when used, is restricted to legally-defined time zones and is represented in HHMM
-	/// format.
-	/// One exception to this rule would be a clinical system that processed patient data collected in a clinic and a nearby hospital
-	/// that happens to be in a different time zone. Such applications may choose to convert the data to a common
-	/// representation. Similar concerns apply to the transitions to and from daylight saving time. HL7 supports such requirements
-	/// by requiring that the time zone information be present when the information is sent. It does not, however, specify which of
-	/// the treatments discussed here will be applied by the receiving system.
-	/// </summary>
-	public class DTM : TSComponentOne
-	{
-		public DTM(IMessage theMessage) : base(theMessage)
-		{
-		}
+   /// <summary>
+   /// Note: The class description below has been excerpted from the Hl7 2.4 documentation. Sectional
+   /// references made below also refer to the same documentation.
+   /// Format: YYYY[MM[DD[HHMM[SS[.S[S[S[S]]]]]]]][+/-ZZZZ]^&lt;degree of precision&gt;
+   /// Contains the exact time of an event, including the date and time. The date portion of a time stamp follows the rules of a
+   /// date field and the time portion follows the rules of a time field. The time zone (+/-ZZZZ) is represented as +/-HHMM
+   /// offset from UTC (formerly Greenwich Mean Time (GMT)), where +0000 or -0000 both represent UTC (without offset).
+   /// The specific data representations used in the HL7 encoding rules are compatible with ISO 8824-1987(E).
+   /// In prior versions of HL7, an optional second component indicates the degree of precision of the time stamp (Y = year, L
+   /// = month, D = day, H = hour, M = minute, S = second). This optional second component is retained only for purposes of
+   /// backward compatibility.
+   /// 
+   /// By site-specific agreement, YYYYMMDD[HHMM[SS[.S[S[S[S]]]]]][+/-ZZZZ]^&lt;degree of precision&gt; may be used
+   /// where backward compatibility must be maintained.
+   /// In the current and future versions of HL7, the precision is indicated by limiting the number of digits used, unless the
+   /// optional second component is present. Thus, YYYY is used to specify a precision of "year," YYYYMM specifies a
+   /// precision of "month," YYYYMMDD specifies a precision of "day," YYYYMMDDHH is used to specify a precision of
+   /// "hour," YYYYMMDDHHMM is used to specify a precision of "minute," YYYYMMDDHHMMSS is used to specify a
+   /// precision of seconds, and YYYYMMDDHHMMSS.SSSS is used to specify a precision of ten thousandths of a second.
+   /// In each of these cases, the time zone is an optional component. Note that if the time zone is not included, the timezone
+   /// defaults to that of the local time zone of the sender. Also note that a TS valued field with the HHMM part set to "0000"
+   /// represents midnight of the night extending from the previous day to the day given by the YYYYMMDD part (see example
+   /// below). Maximum length of the time stamp is 26. 
+   /// 
+   /// Examples:
+   /// |19760704010159-0500|
+   /// 1:01:59 on July 4, 1976 in the Eastern Standard Time zone (USA).
+   /// |19760704010159-0400|
+   /// 1:01:59 on July 4, 1976 in the Eastern Daylight Saving Time zone (USA).
+   /// |198807050000|
+   /// Midnight of the night extending from July 4 to July 5, 1988 in the local time zone of the sender.
+   /// |19880705|
+   /// Same as prior example, but precision extends only to the day. Could be used for a birthdate, if the time of birth is
+   /// unknown.
+   /// |19981004010159+0100|
+   /// 1:01:59 on October 4, 1998 in Amsterdam, NL. (Time zone=+0100).
+   /// The HL7 Standard strongly recommends that all systems routinely send the time zone offset but does not require it. All
+   /// HL7 systems are required to accept the time zone offset, but its implementation is application specific. For many
+   /// applications the time of interest is the local time of the sender. For example, an application in the Eastern Standard Time
+   /// zone receiving notification of an admission that takes place at 11:00 PM in San Francisco on December 11 would prefer
+   /// to treat the admission as having occurred on December 11 rather than advancing the date to December 12.
+   /// Note: The time zone [+/-ZZZZ], when used, is restricted to legally-defined time zones and is represented in HHMM
+   /// format.
+   /// One exception to this rule would be a clinical system that processed patient data collected in a clinic and a nearby hospital
+   /// that happens to be in a different time zone. Such applications may choose to convert the data to a common
+   /// representation. Similar concerns apply to the transitions to and from daylight saving time. HL7 supports such requirements
+   /// by requiring that the time zone information be present when the information is sent. It does not, however, specify which of
+   /// the treatments discussed here will be applied by the receiving system.
+   /// </summary>
+   public class DTM : TSComponentOne
+   {
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public DTM(IMessage theMessage)
+	  		: base(theMessage)
+	  {
+	  }
 
-		public DTM(IMessage theMessage, string description) : base(theMessage, description)
-		{
-		}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public DTM(IMessage theMessage, string description)
+	  		: base(theMessage, description)
+	  {
+	  }
 
-		public string getVersion()
-		{
-			return Constants.VERSION;
-		}
-	}
+	  public string getVersion()
+	  {
+		 return Constants.VERSION;
+	  }
+   }
 }

--- a/src/NHapi.Model.V28/Datatype/ID.cs
+++ b/src/NHapi.Model.V28/Datatype/ID.cs
@@ -3,38 +3,53 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V28.Datatype
 {
-/// <summary>/// Summary description for ID.
-/// </summary>
-public class ID: NHapi.Base.Model.Primitive.ID
-{
-/// <summary>Return the version
-/// <returns>2.8</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for ID.
+   /// </summary>
+   public class ID : NHapi.Base.Model.Primitive.ID
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.8</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.8";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.8";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public ID(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public ID(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///</summary>
-                public ID(IMessage theMessage,int theTable):base(theMessage, theTable)
-                {}
-                
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  public ID(IMessage theMessage, int theTable)
+		  : base(theMessage, theTable)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public ID(IMessage message, int theTable, string description) : base(message,theTable, description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public ID(IMessage theMessage, int theTable, string description)
+		  : base(theMessage, theTable, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V28/Datatype/IS.cs
+++ b/src/NHapi.Model.V28/Datatype/IS.cs
@@ -3,38 +3,54 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V28.Datatype
 {
-/// <summary>/// Summary description for IS.
-/// </summary>
-public class IS: NHapi.Base.Model.Primitive.IS
-{
-/// <summary>Return the version
-/// <returns>2.8</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for IS.
+   /// </summary>
+   public class IS : NHapi.Base.Model.Primitive.IS
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.8</returns>
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.8";
-			    }
-		    }
-            
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.8";
+		 }
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public IS(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///</summary>
-                public IS(IMessage theMessage,int theTable):base(theMessage, theTable)
-                {}
-                
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public IS(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  public IS(IMessage theMessage, int theTable)
+	  		: base(theMessage, theTable)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public IS(IMessage message, int theTable, string description) : base(message,theTable, description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="message">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public IS(IMessage message, int theTable, string description)
+	  		: base(message, theTable, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V28/Datatype/TM.cs
+++ b/src/NHapi.Model.V28/Datatype/TM.cs
@@ -3,36 +3,36 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V28.Datatype
 {
-/// <summary>/// Summary description for TM.
-/// </summary>
-public class TM: NHapi.Base.Model.Primitive.TM
-{
-/// <summary>Return the version
-/// <returns>2.8</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for TM.
+   /// </summary>
+   public class TM : NHapi.Base.Model.Primitive.TM
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.8</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.8";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.8";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public TM(IMessage theMessage)
+	  		: base(theMessage)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///</summary>
-                public TM(IMessage theMessage):base(theMessage)
-                {}
-                
-
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public TM(IMessage message, string description) : base(message,description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public TM(IMessage theMessage, string description)
+	  		: base(theMessage, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V28/Datatype/XAD.cs
+++ b/src/NHapi.Model.V28/Datatype/XAD.cs
@@ -20,7 +20,7 @@ namespace NHapi.Model.V28.Datatype
 /// <li>County/Parish Code (CWE)</li>
 /// <li>Census Tract (CWE)</li>
 /// <li>Address Representation Code (ID)</li>
-/// <li>Address Validity Range (XAD)</li>
+/// <li>Address Validity Range (ST)</li>
 /// <li>Effective Date (DTM)</li>
 /// <li>Expiration Date (DTM)</li>
 /// <li>Expiration Reason (CWE)</li>
@@ -62,7 +62,7 @@ public class XAD : AbstractType, IComposite{
 		data[8] = new CWE(message,"County/Parish Code");
 		data[9] = new CWE(message,"Census Tract");
 		data[10] = new ID(message, 465,"Address Representation Code");
-		data[11] = new XAD(message,"Address Validity Range");
+		data[11] = new ST(message,"Address Validity Range");
 		data[12] = new DTM(message,"Effective Date");
 		data[13] = new DTM(message,"Expiration Date");
 		data[14] = new CWE(message,"Expiration Reason");
@@ -293,11 +293,11 @@ get{
 	/// Returns Address Validity Range (component #11).  This is a convenience method that saves you from 
 	/// casting and handling an exception.
 	///</summary>
-	public XAD AddressValidityRange {
+	public ST AddressValidityRange {
 get{
-	   XAD ret = null;
+	   ST ret = null;
 	   try {
-	      ret = (XAD)this[11];
+	      ret = (ST)this[11];
 	   } catch (DataTypeException e) {
 	      HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem accessing known data type component - this is a bug.", e);
 	      throw new System.Exception("An unexpected error ocurred",e);

--- a/src/NHapi.Model.V28/Datatype/XON.cs
+++ b/src/NHapi.Model.V28/Datatype/XON.cs
@@ -11,9 +11,9 @@ namespace NHapi.Model.V28.Datatype
 /// <p>The HL7 XON (Extended Composite Name and Identification Number for Organizations) data type.  Consists of the following components: </p><ol>
 /// <li>Organization Name (ST)</li>
 /// <li>Organization Name Type Code (CWE)</li>
-/// <li>ID Number (XON)</li>
-/// <li>Identifier Check Digit (XON)</li>
-/// <li>Check Digit Scheme (XON)</li>
+/// <li>ID Number (ST)</li>
+/// <li>Identifier Check Digit (ST)</li>
+/// <li>Check Digit Scheme (ST)</li>
 /// <li>Assigning Authority (HD)</li>
 /// <li>Identifier Type Code (ID)</li>
 /// <li>Assigning Facility (HD)</li>
@@ -40,9 +40,9 @@ public class XON : AbstractType, IComposite{
 		data = new IType[10];
 		data[0] = new ST(message,"Organization Name");
 		data[1] = new CWE(message,"Organization Name Type Code");
-		data[2] = new XON(message,"ID Number");
-		data[3] = new XON(message,"Identifier Check Digit");
-		data[4] = new XON(message,"Check Digit Scheme");
+		data[2] = new ST(message,"ID Number");
+		data[3] = new ST(message,"Identifier Check Digit");
+		data[4] = new ST(message,"Check Digit Scheme");
 		data[5] = new HD(message,"Assigning Authority");
 		data[6] = new ID(message, 203,"Identifier Type Code");
 		data[7] = new HD(message,"Assigning Facility");
@@ -114,11 +114,11 @@ get{
 	/// Returns ID Number (component #2).  This is a convenience method that saves you from 
 	/// casting and handling an exception.
 	///</summary>
-	public XON IDNumber {
+	public ST IDNumber {
 get{
-	   XON ret = null;
+	   ST ret = null;
 	   try {
-	      ret = (XON)this[2];
+	      ret = (ST)this[2];
 	   } catch (DataTypeException e) {
 	      HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem accessing known data type component - this is a bug.", e);
 	      throw new System.Exception("An unexpected error ocurred",e);
@@ -131,11 +131,11 @@ get{
 	/// Returns Identifier Check Digit (component #3).  This is a convenience method that saves you from 
 	/// casting and handling an exception.
 	///</summary>
-	public XON IdentifierCheckDigit {
+	public ST IdentifierCheckDigit {
 get{
-	   XON ret = null;
+	   ST ret = null;
 	   try {
-	      ret = (XON)this[3];
+	      ret = (ST)this[3];
 	   } catch (DataTypeException e) {
 	      HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem accessing known data type component - this is a bug.", e);
 	      throw new System.Exception("An unexpected error ocurred",e);
@@ -148,11 +148,11 @@ get{
 	/// Returns Check Digit Scheme (component #4).  This is a convenience method that saves you from 
 	/// casting and handling an exception.
 	///</summary>
-	public XON CheckDigitScheme {
+	public ST CheckDigitScheme {
 get{
-	   XON ret = null;
+	   ST ret = null;
 	   try {
-	      ret = (XON)this[4];
+	      ret = (ST)this[4];
 	   } catch (DataTypeException e) {
 	      HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem accessing known data type component - this is a bug.", e);
 	      throw new System.Exception("An unexpected error ocurred",e);

--- a/src/NHapi.Model.V28/Datatype/XTN.cs
+++ b/src/NHapi.Model.V28/Datatype/XTN.cs
@@ -9,7 +9,7 @@ namespace NHapi.Model.V28.Datatype
 
 ///<summary>
 /// <p>The HL7 XTN (Extended Telecommunication Number) data type.  Consists of the following components: </p><ol>
-/// <li>Telephone Number (XTN)</li>
+/// <li>Telephone Number (ST)</li>
 /// <li>Telecommunication Use Code (ID)</li>
 /// <li>Telecommunication Equipment Type (ID)</li>
 /// <li>Communication Address (ST)</li>
@@ -46,7 +46,7 @@ public class XTN : AbstractType, IComposite{
 	///</summary>
 	public XTN(IMessage message, string description) : base(message, description){
 		data = new IType[18];
-		data[0] = new XTN(message,"Telephone Number");
+		data[0] = new ST(message,"Telephone Number");
 		data[1] = new ID(message, 201,"Telecommunication Use Code");
 		data[2] = new ID(message, 202,"Telecommunication Equipment Type");
 		data[3] = new ST(message,"Communication Address");
@@ -96,11 +96,11 @@ get{
 	/// Returns Telephone Number (component #0).  This is a convenience method that saves you from 
 	/// casting and handling an exception.
 	///</summary>
-	public XTN TelephoneNumber {
+	public ST TelephoneNumber {
 get{
-	   XTN ret = null;
+	   ST ret = null;
 	   try {
-	      ret = (XTN)this[0];
+	      ret = (ST)this[0];
 	   } catch (DataTypeException e) {
 	      HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem accessing known data type component - this is a bug.", e);
 	      throw new System.Exception("An unexpected error ocurred",e);

--- a/src/NHapi.Model.V281/Datatype/DT.cs
+++ b/src/NHapi.Model.V281/Datatype/DT.cs
@@ -3,36 +3,36 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V281.Datatype
 {
-/// <summary>/// Summary description for DT.
-/// </summary>
-public class DT: NHapi.Base.Model.Primitive.DT
-{
-/// <summary>Return the version
-/// <returns>2.8.1</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for DT.
+   /// </summary>
+   public class DT : NHapi.Base.Model.Primitive.DT
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.8.1</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.8.1";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.8.1";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public DT(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///</summary>
-                public DT(IMessage theMessage):base(theMessage)
-                {}
-                
-
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public DT(IMessage message, string description) : base(message,description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public DT(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V281/Datatype/DTM.cs
+++ b/src/NHapi.Model.V281/Datatype/DTM.cs
@@ -3,68 +3,75 @@ using NHapi.Base.Model.Primitive;
 
 namespace NHapi.Model.V281.Datatype
 {
-	/// <summary>
-	/// Note: The class description below has been excerpted from the Hl7 2.4 documentation. Sectional
-	/// references made below also refer to the same documentation.
-	/// Format: YYYY[MM[DD[HHMM[SS[.S[S[S[S]]]]]]]][+/-ZZZZ]^&lt;degree of precision&gt;
-	/// Contains the exact time of an event, including the date and time. The date portion of a time stamp follows the rules of a
-	/// date field and the time portion follows the rules of a time field. The time zone (+/-ZZZZ) is represented as +/-HHMM
-	/// offset from UTC (formerly Greenwich Mean Time (GMT)), where +0000 or -0000 both represent UTC (without offset).
-	/// The specific data representations used in the HL7 encoding rules are compatible with ISO 8824-1987(E).
-	/// In prior versions of HL7, an optional second component indicates the degree of precision of the time stamp (Y = year, L
-	/// = month, D = day, H = hour, M = minute, S = second). This optional second component is retained only for purposes of
-	/// backward compatibility.
-	/// 
-	/// By site-specific agreement, YYYYMMDD[HHMM[SS[.S[S[S[S]]]]]][+/-ZZZZ]^&lt;degree of precision&gt; may be used
-	/// where backward compatibility must be maintained.
-	/// In the current and future versions of HL7, the precision is indicated by limiting the number of digits used, unless the
-	/// optional second component is present. Thus, YYYY is used to specify a precision of "year," YYYYMM specifies a
-	/// precision of "month," YYYYMMDD specifies a precision of "day," YYYYMMDDHH is used to specify a precision of
-	/// "hour," YYYYMMDDHHMM is used to specify a precision of "minute," YYYYMMDDHHMMSS is used to specify a
-	/// precision of seconds, and YYYYMMDDHHMMSS.SSSS is used to specify a precision of ten thousandths of a second.
-	/// In each of these cases, the time zone is an optional component. Note that if the time zone is not included, the timezone
-	/// defaults to that of the local time zone of the sender. Also note that a TS valued field with the HHMM part set to "0000"
-	/// represents midnight of the night extending from the previous day to the day given by the YYYYMMDD part (see example
-	/// below). Maximum length of the time stamp is 26. 
-	/// 
-	/// Examples:
-	/// |19760704010159-0500|
-	/// 1:01:59 on July 4, 1976 in the Eastern Standard Time zone (USA).
-	/// |19760704010159-0400|
-	/// 1:01:59 on July 4, 1976 in the Eastern Daylight Saving Time zone (USA).
-	/// |198807050000|
-	/// Midnight of the night extending from July 4 to July 5, 1988 in the local time zone of the sender.
-	/// |19880705|
-	/// Same as prior example, but precision extends only to the day. Could be used for a birthdate, if the time of birth is
-	/// unknown.
-	/// |19981004010159+0100|
-	/// 1:01:59 on October 4, 1998 in Amsterdam, NL. (Time zone=+0100).
-	/// The HL7 Standard strongly recommends that all systems routinely send the time zone offset but does not require it. All
-	/// HL7 systems are required to accept the time zone offset, but its implementation is application specific. For many
-	/// applications the time of interest is the local time of the sender. For example, an application in the Eastern Standard Time
-	/// zone receiving notification of an admission that takes place at 11:00 PM in San Francisco on December 11 would prefer
-	/// to treat the admission as having occurred on December 11 rather than advancing the date to December 12.
-	/// Note: The time zone [+/-ZZZZ], when used, is restricted to legally-defined time zones and is represented in HHMM
-	/// format.
-	/// One exception to this rule would be a clinical system that processed patient data collected in a clinic and a nearby hospital
-	/// that happens to be in a different time zone. Such applications may choose to convert the data to a common
-	/// representation. Similar concerns apply to the transitions to and from daylight saving time. HL7 supports such requirements
-	/// by requiring that the time zone information be present when the information is sent. It does not, however, specify which of
-	/// the treatments discussed here will be applied by the receiving system.
-	/// </summary>
-	public class DTM : TSComponentOne
-	{
-		public DTM(IMessage theMessage) : base(theMessage)
-		{
-		}
+   /// <summary>
+   /// Note: The class description below has been excerpted from the Hl7 2.4 documentation. Sectional
+   /// references made below also refer to the same documentation.
+   /// Format: YYYY[MM[DD[HHMM[SS[.S[S[S[S]]]]]]]][+/-ZZZZ]^&lt;degree of precision&gt;
+   /// Contains the exact time of an event, including the date and time. The date portion of a time stamp follows the rules of a
+   /// date field and the time portion follows the rules of a time field. The time zone (+/-ZZZZ) is represented as +/-HHMM
+   /// offset from UTC (formerly Greenwich Mean Time (GMT)), where +0000 or -0000 both represent UTC (without offset).
+   /// The specific data representations used in the HL7 encoding rules are compatible with ISO 8824-1987(E).
+   /// In prior versions of HL7, an optional second component indicates the degree of precision of the time stamp (Y = year, L
+   /// = month, D = day, H = hour, M = minute, S = second). This optional second component is retained only for purposes of
+   /// backward compatibility.
+   /// 
+   /// By site-specific agreement, YYYYMMDD[HHMM[SS[.S[S[S[S]]]]]][+/-ZZZZ]^&lt;degree of precision&gt; may be used
+   /// where backward compatibility must be maintained.
+   /// In the current and future versions of HL7, the precision is indicated by limiting the number of digits used, unless the
+   /// optional second component is present. Thus, YYYY is used to specify a precision of "year," YYYYMM specifies a
+   /// precision of "month," YYYYMMDD specifies a precision of "day," YYYYMMDDHH is used to specify a precision of
+   /// "hour," YYYYMMDDHHMM is used to specify a precision of "minute," YYYYMMDDHHMMSS is used to specify a
+   /// precision of seconds, and YYYYMMDDHHMMSS.SSSS is used to specify a precision of ten thousandths of a second.
+   /// In each of these cases, the time zone is an optional component. Note that if the time zone is not included, the timezone
+   /// defaults to that of the local time zone of the sender. Also note that a TS valued field with the HHMM part set to "0000"
+   /// represents midnight of the night extending from the previous day to the day given by the YYYYMMDD part (see example
+   /// below). Maximum length of the time stamp is 26. 
+   /// 
+   /// Examples:
+   /// |19760704010159-0500|
+   /// 1:01:59 on July 4, 1976 in the Eastern Standard Time zone (USA).
+   /// |19760704010159-0400|
+   /// 1:01:59 on July 4, 1976 in the Eastern Daylight Saving Time zone (USA).
+   /// |198807050000|
+   /// Midnight of the night extending from July 4 to July 5, 1988 in the local time zone of the sender.
+   /// |19880705|
+   /// Same as prior example, but precision extends only to the day. Could be used for a birthdate, if the time of birth is
+   /// unknown.
+   /// |19981004010159+0100|
+   /// 1:01:59 on October 4, 1998 in Amsterdam, NL. (Time zone=+0100).
+   /// The HL7 Standard strongly recommends that all systems routinely send the time zone offset but does not require it. All
+   /// HL7 systems are required to accept the time zone offset, but its implementation is application specific. For many
+   /// applications the time of interest is the local time of the sender. For example, an application in the Eastern Standard Time
+   /// zone receiving notification of an admission that takes place at 11:00 PM in San Francisco on December 11 would prefer
+   /// to treat the admission as having occurred on December 11 rather than advancing the date to December 12.
+   /// Note: The time zone [+/-ZZZZ], when used, is restricted to legally-defined time zones and is represented in HHMM
+   /// format.
+   /// One exception to this rule would be a clinical system that processed patient data collected in a clinic and a nearby hospital
+   /// that happens to be in a different time zone. Such applications may choose to convert the data to a common
+   /// representation. Similar concerns apply to the transitions to and from daylight saving time. HL7 supports such requirements
+   /// by requiring that the time zone information be present when the information is sent. It does not, however, specify which of
+   /// the treatments discussed here will be applied by the receiving system.
+   /// </summary>
+   public class DTM : TSComponentOne
+   {
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public DTM(IMessage theMessage)
+	  		: base(theMessage)
+	  {
+	  }
 
-		public DTM(IMessage theMessage, string description) : base(theMessage, description)
-		{
-		}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public DTM(IMessage theMessage, string description)
+	  		: base(theMessage, description)
+	  {
+	  }
 
-		public string getVersion()
-		{
-			return Constants.VERSION;
-		}
-	}
+	  public string getVersion()
+	  {
+		 return Constants.VERSION;
+	  }
+   }
 }

--- a/src/NHapi.Model.V281/Datatype/ID.cs
+++ b/src/NHapi.Model.V281/Datatype/ID.cs
@@ -3,38 +3,53 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V281.Datatype
 {
-/// <summary>/// Summary description for ID.
-/// </summary>
-public class ID: NHapi.Base.Model.Primitive.ID
-{
-/// <summary>Return the version
-/// <returns>2.8.1</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for ID.
+   /// </summary>
+   public class ID : NHapi.Base.Model.Primitive.ID
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.8.1</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.8.1";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.8.1";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public ID(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public ID(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///</summary>
-                public ID(IMessage theMessage,int theTable):base(theMessage, theTable)
-                {}
-                
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  public ID(IMessage theMessage, int theTable)
+		  : base(theMessage, theTable)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public ID(IMessage message, int theTable, string description) : base(message,theTable, description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public ID(IMessage theMessage, int theTable, string description)
+		  : base(theMessage, theTable, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V281/Datatype/IS.cs
+++ b/src/NHapi.Model.V281/Datatype/IS.cs
@@ -3,38 +3,54 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V281.Datatype
 {
-/// <summary>/// Summary description for IS.
-/// </summary>
-public class IS: NHapi.Base.Model.Primitive.IS
-{
-/// <summary>Return the version
-/// <returns>2.8.1</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for IS.
+   /// </summary>
+   public class IS : NHapi.Base.Model.Primitive.IS
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.8.1</returns>
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.8.1";
-			    }
-		    }
-            
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.8.1";
+		 }
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public IS(IMessage theMessage)
+		  : base(theMessage)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///</summary>
-                public IS(IMessage theMessage,int theTable):base(theMessage, theTable)
-                {}
-                
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public IS(IMessage theMessage, string description)
+		  : base(theMessage, description)
+	  {
+	  }
 
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  public IS(IMessage theMessage, int theTable)
+	  		: base(theMessage, theTable)
+	  {
+	  }
 
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="theTable">The table which this type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public IS(IMessage message, int theTable, string description) : base(message,theTable, description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="message">message to which this Type belongs</param>
+	  /// <param name="theTable">The table which this type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public IS(IMessage message, int theTable, string description)
+	  		: base(message, theTable, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V281/Datatype/TM.cs
+++ b/src/NHapi.Model.V281/Datatype/TM.cs
@@ -3,36 +3,36 @@ using System;
 using NHapi.Base.Model;
 namespace NHapi.Model.V281.Datatype
 {
-/// <summary>/// Summary description for TM.
-/// </summary>
-public class TM: NHapi.Base.Model.Primitive.TM
-{
-/// <summary>Return the version
-/// <returns>2.8.1</returns>
-///</summary>
+   /// <summary>
+   /// Summary description for TM.
+   /// </summary>
+   public class TM : NHapi.Base.Model.Primitive.TM
+   {
+	  /// <value>
+	  /// Return the version
+	  /// </value>
+	  /// <returns>2.8.1</returns>
+	  virtual public System.String Version
+	  {
+		 get
+		 {
+			return "2.8.1";
+		 }
+	  }
 
-            virtual public System.String Version
-            {
-			    get
-			    {
-				    return "2.8.1";
-			    }
-		    }
-            
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  public TM(IMessage theMessage)
+	  		: base(theMessage)
+	  {
+	  }
 
-
-                ///<summary>Construct the type
-                ///<param name="theMessage">message to which this Type belongs</param>
-                ///</summary>
-                public TM(IMessage theMessage):base(theMessage)
-                {}
-                
-
-
-                ///<summary>Construct the type
-                ///<param name="message">message to which this Type belongs</param>
-                ///<param name="description">The description of this type</param>
-                ///</summary>
-		        public TM(IMessage message, string description) : base(message,description)
-    	        {}
-                }}
+	  /// <summary>Construct the type</summary>
+	  /// <param name="theMessage">message to which this Type belongs</param>
+	  /// <param name="description">The description of this type</param>
+	  public TM(IMessage theMessage, string description)
+	  		: base(theMessage, description)
+	  {
+	  }
+   }
+}

--- a/src/NHapi.Model.V281/Datatype/XAD.cs
+++ b/src/NHapi.Model.V281/Datatype/XAD.cs
@@ -7,34 +7,34 @@ using NHapi.Base.Model.Primitive;
 namespace NHapi.Model.V281.Datatype
 {
 
-///<summary>
-/// <p>The HL7 XAD (Extended Address) data type.  Consists of the following components: </p><ol>
-/// <li>Street Address (SAD)</li>
-/// <li>Other Designation (ST)</li>
-/// <li>City (ST)</li>
-/// <li>State or Province (ST)</li>
-/// <li>Zip or Postal Code (ST)</li>
-/// <li>Country (ID)</li>
-/// <li>Address Type (ID)</li>
-/// <li>Other Geographic Designation (ST)</li>
-/// <li>County/Parish Code (CWE)</li>
-/// <li>Census Tract (CWE)</li>
-/// <li>Address Representation Code (ID)</li>
-/// <li>Address Validity Range (XAD)</li>
-/// <li>Effective Date (DTM)</li>
-/// <li>Expiration Date (DTM)</li>
-/// <li>Expiration Reason (CWE)</li>
-/// <li>Temporary Indicator (ID)</li>
-/// <li>Bad Address Indicator (ID)</li>
-/// <li>Address Usage (ID)</li>
-/// <li>Addressee (ST)</li>
-/// <li>Comment (ST)</li>
-/// <li>Preference Order (NM)</li>
-/// <li>Protection Code (CWE)</li>
-/// <li>Address Identifier (EI)</li>
-/// </ol>
-///</summary>
-[Serializable]
+	///<summary>
+	/// <p>The HL7 XAD (Extended Address) data type.  Consists of the following components: </p><ol>
+	/// <li>Street Address (SAD)</li>
+	/// <li>Other Designation (ST)</li>
+	/// <li>City (ST)</li>
+	/// <li>State or Province (ST)</li>
+	/// <li>Zip or Postal Code (ST)</li>
+	/// <li>Country (ID)</li>
+	/// <li>Address Type (ID)</li>
+	/// <li>Other Geographic Designation (ST)</li>
+	/// <li>County/Parish Code (CWE)</li>
+	/// <li>Census Tract (CWE)</li>
+	/// <li>Address Representation Code (ID)</li>
+	/// <li>Address Validity Range (ST)</li>
+	/// <li>Effective Date (DTM)</li>
+	/// <li>Expiration Date (DTM)</li>
+	/// <li>Expiration Reason (CWE)</li>
+	/// <li>Temporary Indicator (ID)</li>
+	/// <li>Bad Address Indicator (ID)</li>
+	/// <li>Address Usage (ID)</li>
+	/// <li>Addressee (ST)</li>
+	/// <li>Comment (ST)</li>
+	/// <li>Preference Order (NM)</li>
+	/// <li>Protection Code (CWE)</li>
+	/// <li>Address Identifier (EI)</li>
+	/// </ol>
+	///</summary>
+	[Serializable]
 public class XAD : AbstractType, IComposite{
 	private IType[] data;
 
@@ -62,7 +62,7 @@ public class XAD : AbstractType, IComposite{
 		data[8] = new CWE(message,"County/Parish Code");
 		data[9] = new CWE(message,"Census Tract");
 		data[10] = new ID(message, 465,"Address Representation Code");
-		data[11] = new XAD(message,"Address Validity Range");
+		data[11] = new ST(message,"Address Validity Range");
 		data[12] = new DTM(message,"Effective Date");
 		data[13] = new DTM(message,"Expiration Date");
 		data[14] = new CWE(message,"Expiration Reason");
@@ -293,11 +293,11 @@ get{
 	/// Returns Address Validity Range (component #11).  This is a convenience method that saves you from 
 	/// casting and handling an exception.
 	///</summary>
-	public XAD AddressValidityRange {
+	public ST AddressValidityRange {
 get{
-	   XAD ret = null;
+		ST ret = null;
 	   try {
-	      ret = (XAD)this[11];
+	      ret = (ST)this[11];
 	   } catch (DataTypeException e) {
 	      HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem accessing known data type component - this is a bug.", e);
 	      throw new System.Exception("An unexpected error ocurred",e);

--- a/src/NHapi.Model.V281/Datatype/XON.cs
+++ b/src/NHapi.Model.V281/Datatype/XON.cs
@@ -11,9 +11,9 @@ namespace NHapi.Model.V281.Datatype
 /// <p>The HL7 XON (Extended Composite Name and Identification Number for Organizations) data type.  Consists of the following components: </p><ol>
 /// <li>Organization Name (ST)</li>
 /// <li>Organization Name Type Code (CWE)</li>
-/// <li>ID Number (XON)</li>
-/// <li>Identifier Check Digit (XON)</li>
-/// <li>Check Digit Scheme (XON)</li>
+/// <li>ID Number (ST)</li>
+/// <li>Identifier Check Digit (ST)</li>
+/// <li>Check Digit Scheme (ST)</li>
 /// <li>Assigning Authority (HD)</li>
 /// <li>Identifier Type Code (ID)</li>
 /// <li>Assigning Facility (HD)</li>
@@ -40,9 +40,9 @@ public class XON : AbstractType, IComposite{
 		data = new IType[10];
 		data[0] = new ST(message,"Organization Name");
 		data[1] = new CWE(message,"Organization Name Type Code");
-		data[2] = new XON(message,"ID Number");
-		data[3] = new XON(message,"Identifier Check Digit");
-		data[4] = new XON(message,"Check Digit Scheme");
+		data[2] = new ST(message,"ID Number");
+		data[3] = new ST(message,"Identifier Check Digit");
+		data[4] = new ST(message,"Check Digit Scheme");
 		data[5] = new HD(message,"Assigning Authority");
 		data[6] = new ID(message, 203,"Identifier Type Code");
 		data[7] = new HD(message,"Assigning Facility");
@@ -114,11 +114,11 @@ get{
 	/// Returns ID Number (component #2).  This is a convenience method that saves you from 
 	/// casting and handling an exception.
 	///</summary>
-	public XON IDNumber {
+	public ST IDNumber {
 get{
-	   XON ret = null;
+	   ST ret = null;
 	   try {
-	      ret = (XON)this[2];
+	      ret = (ST)this[2];
 	   } catch (DataTypeException e) {
 	      HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem accessing known data type component - this is a bug.", e);
 	      throw new System.Exception("An unexpected error ocurred",e);
@@ -131,11 +131,11 @@ get{
 	/// Returns Identifier Check Digit (component #3).  This is a convenience method that saves you from 
 	/// casting and handling an exception.
 	///</summary>
-	public XON IdentifierCheckDigit {
+	public ST IdentifierCheckDigit {
 get{
-	   XON ret = null;
+		ST ret = null;
 	   try {
-	      ret = (XON)this[3];
+	      ret = (ST)this[3];
 	   } catch (DataTypeException e) {
 	      HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem accessing known data type component - this is a bug.", e);
 	      throw new System.Exception("An unexpected error ocurred",e);
@@ -148,11 +148,11 @@ get{
 	/// Returns Check Digit Scheme (component #4).  This is a convenience method that saves you from 
 	/// casting and handling an exception.
 	///</summary>
-	public XON CheckDigitScheme {
+	public ST CheckDigitScheme {
 get{
-	   XON ret = null;
+		ST ret = null;
 	   try {
-	      ret = (XON)this[4];
+	      ret = (ST)this[4];
 	   } catch (DataTypeException e) {
 	      HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem accessing known data type component - this is a bug.", e);
 	      throw new System.Exception("An unexpected error ocurred",e);

--- a/src/NHapi.Model.V281/Datatype/XTN.cs
+++ b/src/NHapi.Model.V281/Datatype/XTN.cs
@@ -7,29 +7,29 @@ using NHapi.Base.Model.Primitive;
 namespace NHapi.Model.V281.Datatype
 {
 
-///<summary>
-/// <p>The HL7 XTN (Extended Telecommunication Number) data type.  Consists of the following components: </p><ol>
-/// <li>Telephone Number (XTN)</li>
-/// <li>Telecommunication Use Code (ID)</li>
-/// <li>Telecommunication Equipment Type (ID)</li>
-/// <li>Communication Address (ST)</li>
-/// <li>Country Code (SNM)</li>
-/// <li>Area/City Code (SNM)</li>
-/// <li>Local Number (SNM)</li>
-/// <li>Extension (SNM)</li>
-/// <li>Any Text (ST)</li>
-/// <li>Extension Prefix (ST)</li>
-/// <li>Speed Dial Code (ST)</li>
-/// <li>Unformatted Telephone number (ST)</li>
-/// <li>Effective Start Date (DTM)</li>
-/// <li>Expiration Date (DTM)</li>
-/// <li>Expiration Reason (CWE)</li>
-/// <li>Protection Code (CWE)</li>
-/// <li>Shared Telecommunication Identifier (EI)</li>
-/// <li>Preference Order (NM)</li>
-/// </ol>
-///</summary>
-[Serializable]
+	///<summary>
+	/// <p>The HL7 XTN (Extended Telecommunication Number) data type.  Consists of the following components: </p><ol>
+	/// <li>Telephone Number (ST)</li>
+	/// <li>Telecommunication Use Code (ID)</li>
+	/// <li>Telecommunication Equipment Type (ID)</li>
+	/// <li>Communication Address (ST)</li>
+	/// <li>Country Code (SNM)</li>
+	/// <li>Area/City Code (SNM)</li>
+	/// <li>Local Number (SNM)</li>
+	/// <li>Extension (SNM)</li>
+	/// <li>Any Text (ST)</li>
+	/// <li>Extension Prefix (ST)</li>
+	/// <li>Speed Dial Code (ST)</li>
+	/// <li>Unformatted Telephone number (ST)</li>
+	/// <li>Effective Start Date (DTM)</li>
+	/// <li>Expiration Date (DTM)</li>
+	/// <li>Expiration Reason (CWE)</li>
+	/// <li>Protection Code (CWE)</li>
+	/// <li>Shared Telecommunication Identifier (EI)</li>
+	/// <li>Preference Order (NM)</li>
+	/// </ol>
+	///</summary>
+	[Serializable]
 public class XTN : AbstractType, IComposite{
 	private IType[] data;
 
@@ -46,7 +46,7 @@ public class XTN : AbstractType, IComposite{
 	///</summary>
 	public XTN(IMessage message, string description) : base(message, description){
 		data = new IType[18];
-		data[0] = new XTN(message,"Telephone Number");
+		data[0] = new ST(message,"Telephone Number");
 		data[1] = new ID(message, 201,"Telecommunication Use Code");
 		data[2] = new ID(message, 202,"Telecommunication Equipment Type");
 		data[3] = new ST(message,"Communication Address");
@@ -96,11 +96,11 @@ get{
 	/// Returns Telephone Number (component #0).  This is a convenience method that saves you from 
 	/// casting and handling an exception.
 	///</summary>
-	public XTN TelephoneNumber {
+	public ST TelephoneNumber {
 get{
-	   XTN ret = null;
+		ST ret = null;
 	   try {
-	      ret = (XTN)this[0];
+	      ret = (ST)this[0];
 	   } catch (DataTypeException e) {
 	      HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem accessing known data type component - this is a bug.", e);
 	      throw new System.Exception("An unexpected error ocurred",e);

--- a/src/NHapi.SourceGeneration/Generators/SegmentElement.cs
+++ b/src/NHapi.SourceGeneration/Generators/SegmentElement.cs
@@ -1,42 +1,43 @@
-/// <summary>The contents of this file are subject to the Mozilla Public License Version 1.1 
-/// (the "License"); you may not use this file except in compliance with the License. 
-/// You may obtain a copy of the License at http://www.mozilla.org/MPL/ 
-/// Software distributed under the License is distributed on an "AS IS" basis, 
-/// WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the 
-/// specific language governing rights and limitations under the License. 
-/// The Original Code is "SegmentElement.java".  Description: 
-/// "A structure for storing a single data element of a segment .." 
-/// The Initial Developer of the Original Code is University Health Network. Copyright (C) 
-/// 2001.  All Rights Reserved. 
-/// Contributor(s): ______________________________________. 
-/// Alternatively, the contents of this file may be used under the terms of the 
-/// GNU General Public License (the  “GPL”), in which case the provisions of the GPL are 
-/// applicable instead of those above.  If you wish to allow use of your version of this 
-/// file only under the terms of the GPL and not to allow others to use your version 
-/// of this file under the MPL, indicate your decision by deleting  the provisions above 
-/// and replace  them with the notice and other provisions required by the GPL License.  
-/// If you do not delete the provisions above, a recipient may use your version of 
-/// this file under either the MPL or the GPL. 
-/// </summary>
-
-using System;
+/*
+	The contents of this file are subject to the Mozilla Public License Version 1.1
+	(the "License"); you may not use this file except in compliance with the License. 
+	You may obtain a copy of the License at http://www.mozilla.org/MPL/ 
+	Software distributed under the License is distributed on an "AS IS" basis, 
+	WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the 
+	specific language governing rights and limitations under the License. 
+	The Original Code is "SegmentElement.java".  Description: 
+	"A structure for storing a single data element of a segment .." 
+	The Initial Developer of the Original Code is University Health Network. Copyright (C) 
+	2001.  All Rights Reserved. 
+	Contributor(s): ______________________________________. 
+	Alternatively, the contents of this file may be used under the terms of the 
+	GNU General Public License (the  “GPL”), in which case the provisions of the GPL are 
+	applicable instead of those above.  If you wish to allow use of your version of this 
+	file only under the terms of the GPL and not to allow others to use your version 
+	of this file under the MPL, indicate your decision by deleting  the provisions above 
+	and replace  them with the notice and other provisions required by the GPL License.  
+	If you do not delete the provisions above, a recipient may use your version of 
+	this file under either the MPL or the GPL. 
+*/
 
 namespace NHapi.SourceGeneration.Generators
 {
-	/// <summary> A structure for storing a single data element of a segment ... </summary>
+	/// <summary>
+	/// A structure for storing a single data element of a segment ...
+	/// </summary>
 	/// <author>  Bryan Tripp (bryan_tripp@sourceforge.net)
 	/// </author>
 	internal class SegmentElement
 	{
 		public int field;
-		public String rep;
-		public String AccessorNameToAppend = string.Empty;
+		public string rep;
+		public string AccessorNameToAppend = string.Empty;
 		public int repetitions;
-		public String desc;
+		public string desc;
 		public int length;
 		public int table;
-		public String opt;
-		public String type;
+		public string opt;
+		public string type;
 
 
 		public virtual string GetDescriptionWithoutSpecialCharacters()
@@ -48,7 +49,9 @@ namespace NHapi.SourceGeneration.Generators
 			return desc;
 		}
 
-		/// <summary>Creates new SegmentElement </summary>
+		/// <summary>
+		/// Creates new SegmentElement
+		/// </summary>
 		public SegmentElement()
 		{
 		}

--- a/tests/NHapi.NUnit/PipeParsingFixture21.cs
+++ b/tests/NHapi.NUnit/PipeParsingFixture21.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using NHapi.Base.Model;
 using NHapi.Base.Parser;
+using NHapi.Model.V21.Datatype;
 using NHapi.Model.V21.Message;
 using NUnit.Framework;
 
@@ -29,5 +31,46 @@ Z01|1||S|NOUVEAU-NE||FATHER NAME^D|||||0||||A||||||N|||1|GFATHER NAME|G-PERE||(4
 			Assert.IsNotNull(parsedMessage);
 			Assert.AreEqual("1144270", parsedMessage.PID.PATIENTIDEXTERNALEXTERNALID.IDNumber.Value);
 		}
+
+		/// <summary>
+		/// https://github.com/nHapiNET/nHapi/issues/135
+		/// </summary>
+		[TestCaseSource(nameof(_validV21ValueTypes))]
+		public void TestObx5DataTypeIsSetFromObx2_AndAllDataTypesAreConstructable(Type expectedObservationValueType)
+		{
+			var message = $@"MSH|^~\&|XPress Arrival||||200610120839||ORU^R01|EBzH1711114101206|P|2.1|||AL|||ASCII
+PID|1||1711114||Appt^Test||19720501||||||||||||001020006
+ORC|||||F
+OBR|1|||ehipack^eHippa Acknowlegment|||200610120839|||||||||00002^eProvider^Electronic|||||||||F
+OBX|1|{expectedObservationValueType.Name}|||{expectedObservationValueType.Name}Value||||||F";
+
+			var parser = new PipeParser();
+
+			var parsed = (ORU_R01)parser.Parse(message);
+
+			var actualObservationValueInstance = parsed.GetPATIENT_RESULT(0).GetORDER_OBSERVATION(0).GetOBSERVATION(0).OBX.OBSERVATIONRESULTS.Data;
+
+			Assert.IsAssignableFrom(expectedObservationValueType, actualObservationValueInstance);
+		}
+
+		/// <summary>
+		/// Specified in Table 0125
+		/// </summary>
+		private static IEnumerable<Type> _validV21ValueTypes = new List<Type>
+		{
+			typeof(AD),
+			typeof(CE),
+			typeof(CK),
+			typeof(CN),
+			typeof(DT),
+			typeof(FT),
+			typeof(NM),
+			typeof(PN),
+			typeof(ST),
+			typeof(TM),
+			typeof(TN),
+			typeof(TS),
+			typeof(TX),
+		};
 	}
 }

--- a/tests/NHapi.NUnit/PipeParsingFixture23.cs
+++ b/tests/NHapi.NUnit/PipeParsingFixture23.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using NHapi.Base.Model;
 using NHapi.Base.Parser;
+using NHapi.Model.V23.Datatype;
 using NHapi.Model.V23.Message;
 using NHapi.Model.V23.Segment;
 using NUnit.Framework;
@@ -362,5 +364,58 @@ PID|1|935307^^^EUH MRN^MRN^EH01|25106376^^^TEC MRN~1781893^^^CLH MRN~935307^^^EU
 				Console.WriteLine(cx.ID.Value);
 			}
 		}
+
+		/// <summary>
+		/// https://github.com/nHapiNET/nHapi/issues/135
+		/// </summary>
+		[TestCaseSource(nameof(_validV23ValueTypes))]
+		public void TestObx5DataTypeIsSetFromObx2_AndAllDataTypesAreConstructable(Type expectedObservationValueType)
+		{
+			var message = $@"MSH|^~\&|XPress Arrival||||200610120839||ORU^R01|EBzH1711114101206|P|2.3|||AL|||ASCII
+PID|1||1711114||Appt^Test||19720501||||||||||||001020006
+ORC|||||F
+OBR|1|||ehipack^eHippa Acknowlegment|||200610120839|||||||||00002^eProvider^Electronic|||||||||F
+OBX|1|{expectedObservationValueType.Name}|||{expectedObservationValueType.Name}Value||||||F";
+
+			var parser = new PipeParser();
+
+			var parsed = (ORU_R01) parser.Parse(message);
+
+			var actualObservationValueType = parsed.GetRESPONSE(0).GetORDER_OBSERVATION(0).GetOBSERVATION(0).OBX.GetObservationValue(0).Data;
+
+			Assert.IsAssignableFrom(expectedObservationValueType, actualObservationValueType);
+		}
+
+		/// <summary>
+		/// Specified in Table 0125
+		/// </summary>
+		private static IEnumerable<Type> _validV23ValueTypes = new List<Type>
+		{
+			typeof(AD),
+			typeof(CE),
+			typeof(CF),
+			typeof(CK),
+			typeof(CN),
+			typeof(CP),
+			typeof(CX),
+			typeof(DT),
+			typeof(ED),
+			typeof(FT),
+			typeof(ID),
+			typeof(MO),
+			typeof(NM),
+			typeof(RP),
+			typeof(SN),
+			typeof(ST),
+			typeof(TM),
+			typeof(TN),
+			typeof(TS),
+			typeof(TX),
+			typeof(XAD),
+			typeof(XCN),
+			typeof(XON),
+			typeof(XPN),
+			typeof(XTN)
+		};
 	}
 }

--- a/tests/NHapi.NUnit/PipeParsingFixture231.cs
+++ b/tests/NHapi.NUnit/PipeParsingFixture231.cs
@@ -1,6 +1,9 @@
+using System;
+using System.Collections.Generic;
 using System.Xml;
 using NHapi.Base.Model;
 using NHapi.Base.Parser;
+using NHapi.Model.V231.Datatype;
 using NHapi.Model.V231.Message;
 using NUnit.Framework;
 
@@ -591,5 +594,59 @@ OBX|6|TX|O2SAT||(Ref Range: 91-95 %)|%|91-95||||F
 OBX|7|NM|FIO2||100.0||||||F
 ";
 		}
+
+		/// <summary>
+		/// https://github.com/nHapiNET/nHapi/issues/135
+		/// </summary>
+		[TestCaseSource(nameof(_validV231DataTypes))]
+		public void TestObx5DataTypeIsSetFromObx2_AndAllDataTypesAreConstructable(Type expectedObservationValueType)
+		{
+			var message = $@"MSH|^~\&|XPress Arrival||||200610120839||ORU^R01|EBzH1711114101206|P|2.3.1|||AL|||ASCII
+PID|1||1711114||Appt^Test||19720501||||||||||||001020006
+ORC|||||F
+OBR|1|||ehipack^eHippa Acknowlegment|||200610120839|||||||||00002^eProvider^Electronic|||||||||F
+OBX|1|{expectedObservationValueType.Name}|||{expectedObservationValueType.Name}Value||||||F";
+
+			var parser = new PipeParser();
+
+			var parsed = (ORU_R01)parser.Parse(message);
+
+			var actualObservationValueType = parsed.GetPATIENT_RESULT(0).GetORDER_OBSERVATION(0).GetOBSERVATION(0).OBX.GetObservationValue(0).Data;
+
+			Assert.IsAssignableFrom(expectedObservationValueType, actualObservationValueType);
+		}
+
+		/// <summary>
+		/// Specified in Table 0125
+		/// </summary>
+		private static IEnumerable<Type> _validV231DataTypes = new List<Type>
+		{
+			typeof(AD),
+			typeof(CE),
+			typeof(CF),
+			typeof(CK),
+			typeof(CN),
+			typeof(CP),
+			typeof(CX),
+			typeof(DT),
+			typeof(ED),
+			typeof(FT),
+			typeof(ID),
+			typeof(MO),
+			typeof(NM),
+			typeof(PN),
+			typeof(RP),
+			typeof(SN),
+			typeof(ST),
+			typeof(TM),
+			typeof(TN),
+			typeof(TS),
+			typeof(TX),
+			typeof(XAD),
+			typeof(XCN),
+			typeof(XON),
+			typeof(XPN),
+			typeof(XTN)
+		};
 	}
 }

--- a/tests/NHapi.NUnit/PipeParsingFixture24.cs
+++ b/tests/NHapi.NUnit/PipeParsingFixture24.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using NHapi.Base;
 using NHapi.Base.Model;
 using NHapi.Base.Parser;
+using NHapi.Model.V24.Datatype;
 using NHapi.Model.V24.Message;
 using NHapi.Model.V24.Segment;
 using NUnit.Framework;
@@ -310,24 +312,24 @@ OBX|1|NM|50026400^HEMOGLOBIN A1C^^50026400^HEMOGLOBIN A1C||12|^% TOTAL HGB|4.0 -
 PID|1|1847|50381^^^^^MOLIS~^^^^^VTD||TEST A^||19711125|F|||test^^Roma^^00144^||||
 ORC|NW|FA9999020000^MOLIS|FA9999020000^MOLIS|FA99990200^MOLIS|CM||^^^20030331053409^^R|||||MOLIS^SYSMEX MOLIS^^^^^^^^^^MOLIS||||||||||||
 OBR|1|FA9999020000^MOLIS|FA9999020000^MOLIS|00^^MOLIS||20030327000000|20030331053409|||||||||MOLIS^SYSMEX MOLIS^^^^^^^^^^MOLIS|||||||||||^^^20030331053409^^R||||||||||||||||||||
-NTE|0||Isolierte Cardiolipin-Autoantikörper vom Typ IgM in niedriger Konzentration sind von fraglicher klinischer Relevanz. Es empfiehlt sich eine Kontrolle aus einer neuen Probe und die zusätzliche Bestimmung der beta-2-Glykoprotein-Autoantikörper.|RE
-NTE|0||Umlaute Test : ÄÖÜäöüßéèàçù|RE
+NTE|0||Isolierte Cardiolipin-Autoantikï¿½rper vom Typ IgM in niedriger Konzentration sind von fraglicher klinischer Relevanz. Es empfiehlt sich eine Kontrolle aus einer neuen Probe und die zusï¿½tzliche Bestimmung der beta-2-Glykoprotein-Autoantikï¿½rper.|RE
+NTE|0||Umlaute Test : ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½|RE
 NTE|0||Ende Test Umlaute|RE
-OBX|1|FT|ALLERG^Allergie^MOLIS||vv Dies eist ein Test zum Drucke\.br\ etwas längeren Textes auf dem Allergiepass||||||C|||20030331053409|||||
+OBX|1|FT|ALLERG^Allergie^MOLIS||vv Dies eist ein Test zum Drucke\.br\ etwas lï¿½ngeren Textes auf dem Allergiepass||||||C|||20030331053409|||||
 ORC|NW|FA9999020018^MOLIS|FA9999020018^MOLIS|FA99990200^MOLIS|CM||^^^20030331053409^^R|||||MOLIS^SYSMEX MOLIS^^^^^^^^^^MOLIS||||||||||||
 OBR|2|FA9999020018^MOLIS|FA9999020018^MOLIS|18^Immunologie^MOLIS||20030327000000|20030331053409|||||||||MOLIS^SYSMEX MOLIS^^^^^^^^^^MOLIS|||||||||||^^^20030331053409^^R||||||||||||||||||||
 OBX|1|TX|ACLAS^Anti-Cardiolipin-Screen^MOLIS||negativ|MOC^^L|(<1.0)||||C|||20030331053409|||||
 OBX|2|NM|ACLAG^Anti-Cardiolipin IgG^MOLIS||0.2|MOC^^L|(<1.0)||||F|||20030331053409|||||
-NTE|1||Bitte beachten: Normwert- und Methodenänderung zum 13.03.03.|RE
+NTE|1||Bitte beachten: Normwert- und Methodenï¿½nderung zum 13.03.03.|RE
 OBX|3|NM|ACLAM^Anti-Cardiolipin IgM^MOLIS||111.3|MOC^^L|(<1.0)|H|||C|||20030331053409|||||
-NTE|1||Bitte beachten: Normwert- und Methodenänderung zum 13.03.03.|RE
+NTE|1||Bitte beachten: Normwert- und Methodenï¿½nderung zum 13.03.03.|RE
 ORC|NW|FA9999020026^MOLIS|FA9999020026^MOLIS|FA99990200^MOLIS|CM||^^^20030331053409^^R|||||MOLIS^SYSMEX MOLIS^^^^^^^^^^MOLIS||||||||||||
 OBR|3|FA9999020026^MOLIS|FA9999020026^MOLIS|26^Hormone^MOLIS||20030327000000|20030331053409|||||||||MOLIS^SYSMEX MOLIS^^^^^^^^^^MOLIS|||||||||||^^^20030331053409^^R||||||||||||||||||||
-OBX|1|NM|FSH^FSH^MOLIS||1.0|U/l^^L|(1.6-12.0)Follikulär \ (8.0-22.0)Peak \ (0.9-12.0)Luteal \ (1.0-17.0)Kontrazeptiva \ (35-151)Menopause||||C|||20030331053409|||||
-OBX|2|NM|LH^LH^MOLIS||37.4|U/l^^L|(1.8-13.4)Follikulär \ (15.6-78.9)Peak \ (0.7-19.4)Luteal \ (1.0-15.0)Kontrazeptiva \ (10.8-61.4)Menopause||||F|||20030331053409|||||
+OBX|1|NM|FSH^FSH^MOLIS||1.0|U/l^^L|(1.6-12.0)Follikulï¿½r \ (8.0-22.0)Peak \ (0.9-12.0)Luteal \ (1.0-17.0)Kontrazeptiva \ (35-151)Menopause||||C|||20030331053409|||||
+OBX|2|NM|LH^LH^MOLIS||37.4|U/l^^L|(1.8-13.4)Follikulï¿½r \ (15.6-78.9)Peak \ (0.7-19.4)Luteal \ (1.0-15.0)Kontrazeptiva \ (10.8-61.4)Menopause||||F|||20030331053409|||||
 OBX|3|NM|LHFSHQ^LH-FSH-Quotient^MOLIS||37.4||(<2.0)|H|||F|||20030331053409|||||
-OBX|4|NM|PROL^Prolactin^MOLIS||10.3|µg/l^^L|(2.3-25.0) \ (2.3-10.0)Menopause||||F|||20030331053409|||||
-OBX|5|NM|E2^Estradiol, E2^MOLIS||39|pmol/l^^L|(70-672)Follikulär \ (551-1938)Peak \ (220-774)Luteal \ (<114)Menopause||||F|||20030331053409||||| ";
+OBX|4|NM|PROL^Prolactin^MOLIS||10.3|ï¿½g/l^^L|(2.3-25.0) \ (2.3-10.0)Menopause||||F|||20030331053409|||||
+OBX|5|NM|E2^Estradiol, E2^MOLIS||39|pmol/l^^L|(70-672)Follikulï¿½r \ (551-1938)Peak \ (220-774)Luteal \ (<114)Menopause||||F|||20030331053409||||| ";
 
 			PipeParser parser = new PipeParser();
 
@@ -402,5 +404,59 @@ OBX|5|NM|E2^Estradiol, E2^MOLIS||39|pmol/l^^L|(70-672)Follikulär \ (551-1938)Pea
 				}
 			}
 		}
+
+		/// <summary>
+		/// https://github.com/nHapiNET/nHapi/issues/135
+		/// </summary>
+		[TestCaseSource(nameof(_validV24ValueTypes))]
+		public void TestObx5DataTypeIsSetFromObx2_AndAllDataTypesAreConstructable(Type expectedObservationValueType)
+		{
+			var message = $@"MSH|^~\&|XPress Arrival||||200610120839||ORU^R01|EBzH1711114101206|P|2.4|||AL|||ASCII
+PID|1||1711114||Appt^Test||19720501||||||||||||001020006
+ORC|||||F
+OBR|1|||ehipack^eHippa Acknowlegment|||200610120839|||||||||00002^eProvider^Electronic|||||||||F
+OBX|1|{expectedObservationValueType.Name}|||{expectedObservationValueType.Name}Value||||||F";
+
+			var parser = new PipeParser();
+
+			var parsed = (ORU_R01)parser.Parse(message);
+
+			var actualObservationValueType = parsed.GetPATIENT_RESULT(0).GetORDER_OBSERVATION(0).GetOBSERVATION(0).OBX.GetObservationValue(0).Data;
+
+			Assert.IsAssignableFrom(expectedObservationValueType, actualObservationValueType);
+		}
+
+		/// <summary>
+		/// Specified in Table 0125
+		/// </summary>
+		private static IEnumerable<Type> _validV24ValueTypes = new List<Type>
+		{
+			typeof(AD),
+			typeof(CE),
+			typeof(CF),
+			typeof(CK),
+			typeof(CN),
+			typeof(CP),
+			typeof(CX),
+			typeof(DT),
+			typeof(ED),
+			typeof(FT),
+			typeof(ID),
+			typeof(MO),
+			typeof(NM),
+			typeof(PN),
+			typeof(RP),
+			typeof(SN),
+			typeof(ST),
+			typeof(TM),
+			typeof(TN),
+			typeof(TS),
+			typeof(TX),
+			typeof(XAD),
+			typeof(XCN),
+			typeof(XON),
+			typeof(XPN),
+			typeof(XTN)
+		};
 	}
 }

--- a/tests/NHapi.NUnit/PipeParsingFixture25.cs
+++ b/tests/NHapi.NUnit/PipeParsingFixture25.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using NHapi.Base.Model;
 using NHapi.Base.Parser;
+using NHapi.Model.V25.Datatype;
 using NHapi.Model.V25.Message;
 using NUnit.Framework;
 
@@ -63,5 +65,55 @@ PV1|1";
 			isSame = string.Compare("ADT_A01", result, StringComparison.InvariantCultureIgnoreCase) == 0;
 			Assert.IsTrue(isSame, "ADT_A01 returns ADT_A01");
 		}
+
+		/// <summary>
+		/// https://github.com/nHapiNET/nHapi/issues/135
+		/// </summary>
+		[TestCaseSource(nameof(_validV25ValueTypes))]
+		public void TestObx5DataTypeIsSetFromObx2_AndAllDataTypesAreConstructable(Type expectedObservationValueType)
+		{
+			var message = $@"MSH|^~\&|XPress Arrival||||200610120839||ORU^R01|EBzH1711114101206|P|2.5|||AL|||ASCII
+PID|1||1711114||Appt^Test||19720501||||||||||||001020006
+ORC|||||F
+OBR|1|||ehipack^eHippa Acknowlegment|||200610120839|||||||||00002^eProvider^Electronic|||||||||F
+OBX|1|{expectedObservationValueType.Name}|||{expectedObservationValueType.Name}Value||||||F";
+
+			var parser = new PipeParser();
+
+			var parsed = (ORU_R01)parser.Parse(message);
+
+			var actualObservationValueType = parsed.GetPATIENT_RESULT(0).GetORDER_OBSERVATION(0).GetOBSERVATION(0).OBX.GetObservationValue(0).Data;
+
+			Assert.IsAssignableFrom(expectedObservationValueType, actualObservationValueType);
+		}
+
+		/// <summary>
+		/// Specified in Table 0125
+		/// </summary>
+		private static IEnumerable<Type> _validV25ValueTypes = new List<Type>
+		{
+			typeof(AD),
+			typeof(CE),
+			typeof(CF),
+			typeof(CP),
+			typeof(CX),
+			typeof(DT),
+			typeof(ED),
+			typeof(FT),
+			typeof(ID),
+			typeof(MO),
+			typeof(NM),
+			typeof(RP),
+			typeof(SN),
+			typeof(ST),
+			typeof(TM),
+			typeof(TS),
+			typeof(TX),
+			typeof(XAD),
+			typeof(XCN),
+			typeof(XON),
+			typeof(XPN),
+			typeof(XTN)
+		};
 	}
 }

--- a/tests/NHapi.NUnit/PipeParsingFixture251.cs
+++ b/tests/NHapi.NUnit/PipeParsingFixture251.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using NHapi.Base.Model;
 using NHapi.Base.Parser;
@@ -110,5 +111,55 @@ PV1|1";
 			isSame = string.Compare("ADT_A01", result, StringComparison.InvariantCultureIgnoreCase) == 0;
 			Assert.IsTrue(isSame, "ADT_A01 returns ADT_A01");
 		}
+
+		/// <summary>
+		/// https://github.com/nHapiNET/nHapi/issues/135
+		/// </summary>
+		[TestCaseSource(nameof(_validV251ValueTypes))]
+		public void TestObx5DataTypeIsSetFromObx2_AndAllDataTypesAreConstructable(Type expectedObservationValueType)
+		{
+			var message = $@"MSH|^~\&|XPress Arrival||||200610120839||ORU^R01|EBzH1711114101206|P|2.5.1|||AL|||ASCII
+PID|1||1711114||Appt^Test||19720501||||||||||||001020006
+ORC|||||F
+OBR|1|||ehipack^eHippa Acknowlegment|||200610120839|||||||||00002^eProvider^Electronic|||||||||F
+OBX|1|{expectedObservationValueType.Name}|||{expectedObservationValueType.Name}Value||||||F";
+
+			var parser = new PipeParser();
+
+			var parsed = (ORU_R01)parser.Parse(message);
+
+			var actualObservationValueType = parsed.GetPATIENT_RESULT(0).GetORDER_OBSERVATION(0).GetOBSERVATION(0).OBX.GetObservationValue(0).Data;
+
+			Assert.IsAssignableFrom(expectedObservationValueType, actualObservationValueType);
+		}
+
+		/// <summary>
+		/// Specified in Table 0125
+		/// </summary>
+		private static IEnumerable<Type> _validV251ValueTypes = new List<Type>
+		{
+			typeof(AD),
+			typeof(CE),
+			typeof(CF),
+			typeof(CP),
+			typeof(CX),
+			typeof(DT),
+			typeof(ED),
+			typeof(FT),
+			typeof(ID),
+			typeof(MO),
+			typeof(NM),
+			typeof(RP),
+			typeof(SN),
+			typeof(ST),
+			typeof(TM),
+			typeof(TS),
+			typeof(TX),
+			typeof(XAD),
+			typeof(XCN),
+			typeof(XON),
+			typeof(XPN),
+			typeof(XTN)
+		};
 	}
 }

--- a/tests/NHapi.NUnit/PipeParsingFixture26.cs
+++ b/tests/NHapi.NUnit/PipeParsingFixture26.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NHapi.Base.Model;
@@ -307,5 +308,55 @@ OBX|3|DTM|||20160627041809+0000||||||P";
 			var knownDTMValue = oruR01.GetPATIENT_RESULT(0).GetORDER_OBSERVATION(0).GetOBSERVATION(0).OBX.GetObservationValue(0).Data as DTM;
 			Assert.AreEqual("20160627041809+0000", knownDTMValue.ToString());
 		}
+
+		/// <summary>
+		/// https://github.com/nHapiNET/nHapi/issues/135
+		/// </summary>
+		[TestCaseSource(nameof(_validV26ValueTypes))]
+		public void TestObx5DataTypeIsSetFromObx2_AndAllDataTypesAreConstructable(Type expectedObservationValueType)
+		{
+			var message = $@"MSH|^~\&|XPress Arrival||||200610120839||ORU^R01|EBzH1711114101206|P|2.6|||AL|||ASCII
+PID|1||1711114||Appt^Test||19720501||||||||||||001020006
+ORC|||||F
+OBR|1|||ehipack^eHippa Acknowlegment|||200610120839|||||||||00002^eProvider^Electronic|||||||||F
+OBX|1|{expectedObservationValueType.Name}|||{expectedObservationValueType.Name}Value||||||F";
+
+			var parser = new PipeParser();
+
+			var parsed = (ORU_R01)parser.Parse(message);
+
+			var actualObservationValueType = parsed.GetPATIENT_RESULT(0).GetORDER_OBSERVATION(0).GetOBSERVATION(0).OBX.GetObservationValue(0).Data;
+
+			Assert.IsAssignableFrom(expectedObservationValueType, actualObservationValueType);
+		}
+
+		/// <summary>
+		/// Specified in Table 0125
+		/// </summary>
+		private static IEnumerable<Type> _validV26ValueTypes = new List<Type>
+		{
+			typeof(AD),
+			typeof(CE),
+			typeof(CF),
+			typeof(CP),
+			typeof(CX),
+			typeof(DT),
+			typeof(ED),
+			typeof(FT),
+			typeof(ID),
+			typeof(MO),
+			typeof(NM),
+			typeof(RP),
+			typeof(SN),
+			typeof(ST),
+			typeof(TM),
+			typeof(TS),
+			typeof(TX),
+			typeof(XAD),
+			typeof(XCN),
+			typeof(XON),
+			typeof(XPN),
+			typeof(XTN)
+		};
 	}
 }

--- a/tests/NHapi.NUnit/PipeParsingFixture27.cs
+++ b/tests/NHapi.NUnit/PipeParsingFixture27.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using NHapi.Base.Model;
 using NHapi.Base.Parser;
@@ -110,5 +111,53 @@ PV1|1";
 			isSame = string.Compare("ADT_A01", result, StringComparison.InvariantCultureIgnoreCase) == 0;
 			Assert.IsTrue(isSame, "ADT_A01 returns ADT_A01");
 		}
+
+		/// <summary>
+		/// https://github.com/nHapiNET/nHapi/issues/135
+		/// </summary>
+		[TestCaseSource(nameof(_validV27ValueTypes))]
+		public void TestObx5DataTypeIsSetFromObx2_AndAllDataTypesAreConstructable(Type expectedObservationValueType)
+		{
+			var message = $@"MSH|^~\&|XPress Arrival||||200610120839||ORU^R01|EBzH1711114101206|P|2.7|||AL|||ASCII
+PID|1||1711114||Appt^Test||19720501||||||||||||001020006
+ORC|||||F
+OBR|1|||ehipack^eHippa Acknowlegment|||200610120839|||||||||00002^eProvider^Electronic|||||||||F
+OBX|1|{expectedObservationValueType.Name}|||{expectedObservationValueType.Name}Value||||||F";
+
+			var parser = new PipeParser();
+
+			var parsed = (ORU_R01)parser.Parse(message);
+
+			var actualObservationValueType = parsed.GetPATIENT_RESULT(0).GetORDER_OBSERVATION(0).GetOBSERVATION(0).OBX.GetObservationValue(0).Data;
+
+			Assert.IsAssignableFrom(expectedObservationValueType, actualObservationValueType);
+		}
+
+		/// <summary>
+		/// Specified in Table 0125
+		/// </summary>
+		private static IEnumerable<Type> _validV27ValueTypes = new List<Type>
+		{
+			typeof(AD),
+			typeof(CF),
+			typeof(CP),
+			typeof(CX),
+			typeof(DT),
+			typeof(ED),
+			typeof(FT),
+			typeof(ID),
+			typeof(MO),
+			typeof(NM),
+			typeof(RP),
+			typeof(SN),
+			typeof(ST),
+			typeof(TM),
+			typeof(TX),
+			typeof(XAD),
+			typeof(XCN),
+			typeof(XON),
+			typeof(XPN),
+			typeof(XTN)
+		};
 	}
 }

--- a/tests/NHapi.NUnit/PipeParsingFixture271.cs
+++ b/tests/NHapi.NUnit/PipeParsingFixture271.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using NHapi.Base.Model;
 using NHapi.Base.Parser;
@@ -110,5 +111,53 @@ PV1|1";
 			isSame = string.Compare("ADT_A01", result, StringComparison.InvariantCultureIgnoreCase) == 0;
 			Assert.IsTrue(isSame, "ADT_A01 returns ADT_A01");
 		}
+
+		/// <summary>
+		/// https://github.com/nHapiNET/nHapi/issues/135
+		/// </summary>
+		[TestCaseSource(nameof(_validV271ValueTypes))]
+		public void TestObx5DataTypeIsSetFromObx2_AndAllDataTypesAreConstructable(Type expectedObservationValueType)
+		{
+			var message = $@"MSH|^~\&|XPress Arrival||||200610120839||ORU^R01|EBzH1711114101206|P|2.7.1|||AL|||ASCII
+PID|1||1711114||Appt^Test||19720501||||||||||||001020006
+ORC|||||F
+OBR|1|||ehipack^eHippa Acknowlegment|||200610120839|||||||||00002^eProvider^Electronic|||||||||F
+OBX|1|{expectedObservationValueType.Name}|||{expectedObservationValueType.Name}Value||||||F";
+
+			var parser = new PipeParser();
+
+			var parsed = (ORU_R01)parser.Parse(message);
+
+			var actualObservationValueType = parsed.GetPATIENT_RESULT(0).GetORDER_OBSERVATION(0).GetOBSERVATION(0).OBX.GetObservationValue(0).Data;
+
+			Assert.IsAssignableFrom(expectedObservationValueType, actualObservationValueType);
+		}
+
+		/// <summary>
+		/// Specified in Table 0125
+		/// </summary>
+		private static IEnumerable<Type> _validV271ValueTypes = new List<Type>
+		{
+			typeof(AD),
+			typeof(CF),
+			typeof(CP),
+			typeof(CX),
+			typeof(DT),
+			typeof(ED),
+			typeof(FT),
+			typeof(ID),
+			typeof(MO),
+			typeof(NM),
+			typeof(RP),
+			typeof(SN),
+			typeof(ST),
+			typeof(TM),
+			typeof(TX),
+			typeof(XAD),
+			typeof(XCN),
+			typeof(XON),
+			typeof(XPN),
+			typeof(XTN)
+		};
 	}
 }

--- a/tests/NHapi.NUnit/PipeParsingFixture28.cs
+++ b/tests/NHapi.NUnit/PipeParsingFixture28.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using NHapi.Base.Model;
 using NHapi.Base.Parser;
@@ -110,5 +111,53 @@ PV1|1";
 			isSame = string.Compare("ADT_A01", result, StringComparison.InvariantCultureIgnoreCase) == 0;
 			Assert.IsTrue(isSame, "ADT_A01 returns ADT_A01");
 		}
+
+		/// <summary>
+		/// https://github.com/nHapiNET/nHapi/issues/135
+		/// </summary>
+		[TestCaseSource(nameof(_validV28ValueTypes))]
+		public void TestObx5DataTypeIsSetFromObx2_AndAllDataTypesAreConstructable(Type expectedObservationValueType)
+		{
+			var message = $@"MSH|^~\&|XPress Arrival||||200610120839||ORU^R01|EBzH1711114101206|P|2.8|||AL|||ASCII
+PID|1||1711114||Appt^Test||19720501||||||||||||001020006
+ORC|||||F
+OBR|1|||ehipack^eHippa Acknowlegment|||200610120839|||||||||00002^eProvider^Electronic|||||||||F
+OBX|1|{expectedObservationValueType.Name}|||{expectedObservationValueType.Name}Value||||||F";
+
+			var parser = new PipeParser();
+
+			var parsed = (ORU_R01)parser.Parse(message);
+
+			var actualObservationValueType = parsed.GetPATIENT_RESULT(0).GetORDER_OBSERVATION(0).GetOBSERVATION(0).OBX.GetObservationValue(0).Data;
+
+			Assert.IsAssignableFrom(expectedObservationValueType, actualObservationValueType);
+		}
+
+		/// <summary>
+		/// Specified in Table 0125
+		/// </summary>
+		private static IEnumerable<Type> _validV28ValueTypes = new List<Type>
+		{
+			typeof(AD),
+			typeof(CF),
+			typeof(CP),
+			typeof(CX),
+			typeof(DT),
+			typeof(ED),
+			typeof(FT),
+			typeof(ID),
+			typeof(MO),
+			typeof(NM),
+			typeof(RP),
+			typeof(SN),
+			typeof(ST),
+			typeof(TM),
+			typeof(TX),
+			typeof(XAD),
+			typeof(XCN),
+			typeof(XON),
+			typeof(XPN),
+			typeof(XTN)
+		};
 	}
 }

--- a/tests/NHapi.NUnit/PipeParsingFixture281.cs
+++ b/tests/NHapi.NUnit/PipeParsingFixture281.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using NHapi.Base.Model;
 using NHapi.Base.Parser;
@@ -110,5 +111,53 @@ PV1|1";
 			isSame = string.Compare("ADT_A01", result, StringComparison.InvariantCultureIgnoreCase) == 0;
 			Assert.IsTrue(isSame, "ADT_A01 returns ADT_A01");
 		}
+
+		/// <summary>
+		/// https://github.com/nHapiNET/nHapi/issues/135
+		/// </summary>
+		[TestCaseSource(nameof(_validV281ValueTypes))]
+		public void TestObx5DataTypeIsSetFromObx2_AndAllDataTypesAreConstructable(Type expectedObservationValueType)
+		{
+			var message = $@"MSH|^~\&|XPress Arrival||||200610120839||ORU^R01|EBzH1711114101206|P|2.8.1|||AL|||ASCII
+PID|1||1711114||Appt^Test||19720501||||||||||||001020006
+ORC|||||F
+OBR|1|||ehipack^eHippa Acknowlegment|||200610120839|||||||||00002^eProvider^Electronic|||||||||F
+OBX|1|{expectedObservationValueType.Name}|||{expectedObservationValueType.Name}Value||||||F";
+
+			var parser = new PipeParser();
+
+			var parsed = (ORU_R01)parser.Parse(message);
+
+			var actualObservationValueInstance = parsed.GetPATIENT_RESULT(0).GetORDER_OBSERVATION(0).GetOBSERVATION(0).OBX.GetObservationValue(0).Data;
+
+			Assert.IsAssignableFrom(expectedObservationValueType, actualObservationValueInstance);
+		}
+
+		/// <summary>
+		/// Specified in Table 0125
+		/// </summary>
+		private static IEnumerable<Type> _validV281ValueTypes = new List<Type>
+		{
+			typeof(AD),
+			typeof(CF),
+			typeof(CP),
+			typeof(CX),
+			typeof(DT),
+			typeof(ED),
+			typeof(FT),
+			typeof(ID),
+			typeof(MO),
+			typeof(NM),
+			typeof(RP),
+			typeof(SN),
+			typeof(ST),
+			typeof(TM),
+			typeof(TX),
+			typeof(XAD),
+			typeof(XCN),
+			typeof(XON),
+			typeof(XPN),
+			typeof(XTN)
+		};
 	}
 }


### PR DESCRIPTION
The datatype for `OBX-5` is specified in `OBX-2`, the first commit fixes an issue when the specified datatype from `OBX-2` could not be constructed for `OBX-5` because the required constructors were missing.
fixes #62, fixes #85, fixes #133

`XAD`, `XON`, `XTN` datatypes for hl7 v2.7.1 up to 2.8.1 have incorrect recursive datatypes leading to `StackOverflowException`.
The second commit fixes this by correcting those datatypes.
fixes #86, fixes #109

The `OBX-5` datatype for hl7 v2.1 is incorrectly set to `ST` when it should be `Varies`. The last commit fixes this.
fixes #45 