### PR TITLE
fix dependabot config, doesnt support globbing or wildcards :(

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,75 @@
 
 version: 2
 updates:
-  - package-ecosystem: "nuget" # See documentation for possible values
-    directory: "/src" # Location of package manifests
+  - package-ecosystem: "nuget" 
+    directory: "/src/NHapi.Base"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "nuget" 
+    directory: "/src/NHapi.Model.V21"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "nuget" 
+    directory: "/src/NHapi.Model.V22"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "nuget" 
+    directory: "/src/NHapi.Model.V22_ZSegments"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "nuget" 
+    directory: "/src/NHapi.Model.V23"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "nuget" 
+    directory: "/src/NHapi.Model.V231"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "nuget" 
+    directory: "/src/NHapi.Model.V24"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "nuget" 
+    directory: "/src/NHapi.Model.V25"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "nuget" 
+    directory: "/src/NHapi.Model.V251"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "nuget" 
+    directory: "/src/NHapi.Model.V26"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "nuget" 
+    directory: "/src/NHapi.Model.V271"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "nuget" 
+    directory: "/src/NHapi.Model.V28"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "nuget" 
+    directory: "/src/NHapi.Model.V281"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "nuget" 
+    directory: "/src/ModelGenerator" 
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "nuget"
+    directory: "/src/NHapi.SourceGeneration"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "nuget"
+    directory: "/tests/NHapi.Base.NUnit"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "nuget"
+    directory: "/tests/NHapi.NUnit"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "nuget"
+    directory: "/tests/NHapi.NUnit.SourceGeneration"
     schedule:
       interval: "daily"


### PR DESCRIPTION
dependabot config is not magic like I thought, doesnt support globbig or wilcards [apparently this is how you do it](https://github.com/dependabot/dependabot-core/issues/2824#issuecomment-741693711).