### PR TITLE
Fix for getStructureName for finding group objects by short name.

### DIFF
--- a/src/NHapi.Base/Model/AbstractGroup.cs
+++ b/src/NHapi.Base/Model/AbstractGroup.cs
@@ -536,7 +536,7 @@ namespace NHapi.Base.Model
         private string GetStructureName(Type c)
         {
             var fullName = c.FullName;
-            var dotLoc = fullName.LastIndexOf('.');
+            int dotLoc = fullName.LastIndexOfAny(new char[] { '.', '_' });
             var name = fullName.Substring(dotLoc + 1, fullName.Length - (dotLoc + 1));
 
             // remove message name prefix from group names for compatibility with getters ...


### PR DESCRIPTION
This fixes failing AddORDER() and GetORDER() function calls for group objects.
Example message item VXU_V04 has VXU_V04_ORDER and VXU_V04_PATIENT which are found by ORDER and PATIENT respectively.
This will fix all versions.