### PR TITLE
Update HL7 v. 2.3 IN1 and IN2 repeat flags for some fields, fixes #191

### DIFF
--- a/src/NHapi.Model.V23/Segment/IN1.cs
+++ b/src/NHapi.Model.V23/Segment/IN1.cs
@@ -78,23 +78,23 @@ public class IN1 : AbstractSegment  {
     try {
        this.add(typeof(SI), true, 1, 4, new System.Object[]{message}, "Set ID - Insurance");
        this.add(typeof(CE), false, 1, 8, new System.Object[]{message}, "Insurance Plan ID");
-       this.add(typeof(CX), true, 1, 59, new System.Object[]{message}, "Insurance Company ID");
-       this.add(typeof(XON), false, 1, 130, new System.Object[]{message}, "Insurance Company Name");
-       this.add(typeof(XAD), false, 1, 106, new System.Object[]{message}, "Insurance Company Address");
-       this.add(typeof(XPN), false, 1, 48, new System.Object[]{message}, "Insurance Co. Contact Ppers");
-       this.add(typeof(XTN), false, 3, 40, new System.Object[]{message}, "Insurance Co Phone Number");
+       this.add(typeof(CX), true, 0, 59, new System.Object[]{message}, "Insurance Company ID");
+       this.add(typeof(XON), false, 0, 130, new System.Object[]{message}, "Insurance Company Name");
+       this.add(typeof(XAD), false, 0, 106, new System.Object[]{message}, "Insurance Company Address");
+       this.add(typeof(XPN), false, 0, 48, new System.Object[]{message}, "Insurance Co. Contact Ppers");
+       this.add(typeof(XTN), false, 0, 40, new System.Object[]{message}, "Insurance Co Phone Number");
        this.add(typeof(ST), false, 1, 12, new System.Object[]{message}, "Group Number");
-       this.add(typeof(XON), false, 1, 130, new System.Object[]{message}, "Group Name");
-       this.add(typeof(CX), false, 1, 12, new System.Object[]{message}, "Insured's group employer ID");
-       this.add(typeof(XON), false, 1, 130, new System.Object[]{message}, "Insured's Group Emp Name");
+       this.add(typeof(XON), false, 0, 130, new System.Object[]{message}, "Group Name");
+       this.add(typeof(CX), false, 0, 12, new System.Object[]{message}, "Insured's group employer ID");
+       this.add(typeof(XON), false, 0, 130, new System.Object[]{message}, "Insured's Group Emp Name");
        this.add(typeof(DT), false, 1, 8, new System.Object[]{message}, "Plan Effective Date");
        this.add(typeof(DT), false, 1, 8, new System.Object[]{message}, "Plan Expiration Date");
        this.add(typeof(CM_AUI), false, 1, 55, new System.Object[]{message}, "Authorization Information");
        this.add(typeof(IS), false, 1, 3, new System.Object[]{message, 86}, "Plan Type");
-       this.add(typeof(XPN), false, 1, 48, new System.Object[]{message}, "Name of Insured");
+       this.add(typeof(XPN), false, 0, 48, new System.Object[]{message}, "Name of Insured");
        this.add(typeof(IS), false, 1, 2, new System.Object[]{message, 63}, "Insured's Relationship to Patient");
        this.add(typeof(TS), false, 1, 26, new System.Object[]{message}, "Insured's Date of Birth");
-       this.add(typeof(XAD), false, 1, 106, new System.Object[]{message}, "Insured's Address");
+       this.add(typeof(XAD), false, 0, 106, new System.Object[]{message}, "Insured's Address");
        this.add(typeof(IS), false, 1, 2, new System.Object[]{message, 135}, "Assignment of Benefits");
        this.add(typeof(IS), false, 1, 2, new System.Object[]{message, 173}, "Coordination of Benefits");
        this.add(typeof(ST), false, 1, 2, new System.Object[]{message}, "Coord of Ben. Priority");
@@ -119,12 +119,12 @@ public class IN1 : AbstractSegment  {
        this.add(typeof(CP), false, 1, 12, new System.Object[]{message}, "Room Rate - Private");
        this.add(typeof(CE), false, 1, 60, new System.Object[]{message}, "Insured's Employment Status");
        this.add(typeof(IS), false, 1, 1, new System.Object[]{message, 1}, "Insured's Sex");
-       this.add(typeof(XAD), false, 1, 106, new System.Object[]{message}, "Insured's Employer Address");
+       this.add(typeof(XAD), false, 0, 106, new System.Object[]{message}, "Insured's Employer Address");
        this.add(typeof(ST), false, 1, 2, new System.Object[]{message}, "Verification Status");
        this.add(typeof(IS), false, 1, 8, new System.Object[]{message, 72}, "Prior Insurance Plan ID");
        this.add(typeof(IS), false, 1, 3, new System.Object[]{message, 309}, "Coverage Type");
        this.add(typeof(IS), false, 1, 2, new System.Object[]{message, 310}, "Handicap");
-       this.add(typeof(CX), false, 1, 12, new System.Object[]{message}, "Insured's ID Number");
+       this.add(typeof(CX), false, 0, 12, new System.Object[]{message}, "Insured's ID Number");
     } catch (HL7Exception he) {
         HapiLogFactory.GetHapiLog(GetType()).Error("Can't instantiate " + GetType().Name, he);
     }
@@ -176,160 +176,380 @@ public class IN1 : AbstractSegment  {
 	}
   }
 
-	///<summary>
-	/// Returns Insurance Company ID(IN1-3).
-	///</summary>
-	public CX InsuranceCompanyID
-	{
-		get{
-			CX ret = null;
-			try
-			{
-			IType t = this.GetField(3, 0);
-				ret = (CX)t;
-			}
-			 catch (HL7Exception he) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
-				throw new System.Exception("An unexpected error ocurred", he);
-		} catch (System.Exception ex) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
-				throw new System.Exception("An unexpected error ocurred", ex);
-    }
-			return ret;
-	}
-  }
-
-	///<summary>
-	/// Returns Insurance Company Name(IN1-4).
-	///</summary>
-	public XON InsuranceCompanyName
-	{
-		get{
-			XON ret = null;
-			try
-			{
-			IType t = this.GetField(4, 0);
-				ret = (XON)t;
-			}
-			 catch (HL7Exception he) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
-				throw new System.Exception("An unexpected error ocurred", he);
-		} catch (System.Exception ex) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
-				throw new System.Exception("An unexpected error ocurred", ex);
-    }
-			return ret;
-	}
-  }
-
-	///<summary>
-	/// Returns Insurance Company Address(IN1-5).
-	///</summary>
-	public XAD InsuranceCompanyAddress
-	{
-		get{
-			XAD ret = null;
-			try
-			{
-			IType t = this.GetField(5, 0);
-				ret = (XAD)t;
-			}
-			 catch (HL7Exception he) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
-				throw new System.Exception("An unexpected error ocurred", he);
-		} catch (System.Exception ex) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
-				throw new System.Exception("An unexpected error ocurred", ex);
-    }
-			return ret;
-	}
-  }
-
-	///<summary>
-	/// Returns Insurance Co. Contact Ppers(IN1-6).
-	///</summary>
-	public XPN InsuranceCoContactPpers
-	{
-		get{
-			XPN ret = null;
-			try
-			{
-			IType t = this.GetField(6, 0);
-				ret = (XPN)t;
-			}
-			 catch (HL7Exception he) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
-				throw new System.Exception("An unexpected error ocurred", he);
-		} catch (System.Exception ex) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
-				throw new System.Exception("An unexpected error ocurred", ex);
-    }
-			return ret;
-	}
-  }
-
-	///<summary>
-	/// Returns a single repetition of Insurance Co Phone Number(IN1-7).
-	/// throws HL7Exception if the repetition number is invalid.
-	/// <param name="rep">The repetition number (this is a repeating field)</param>
-	///</summary>
-	public XTN GetInsuranceCoPhoneNumber(int rep)
-	{
-			XTN ret = null;
-			try
-			{
-			IType t = this.GetField(7, rep);
-				ret = (XTN)t;
-		} catch (System.Exception ex) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
-				throw new System.Exception("An unexpected error ocurred", ex);
-    }
-			return ret;
-  }
-
-  ///<summary>
-  /// Returns all repetitions of Insurance Co Phone Number (IN1-7).
-   ///</summary>
-  public XTN[] GetInsuranceCoPhoneNumber() {
-     XTN[] ret = null;
-    try {
-        IType[] t = this.GetField(7);  
-        ret = new XTN[t.Length];
-        for (int i = 0; i < ret.Length; i++) {
-            ret[i] = (XTN)t[i];
+    ///<summary>
+    /// Returns a single repetition of Insurance Company ID(IN1-3).
+    /// throws HL7Exception if the repetition number is invalid.
+    /// <param name="rep">The repetition number (this is a repeating field)</param>
+    ///</summary>
+    public CX GetInsuranceCompanyID(int rep)
+    {
+        CX ret = null;
+        try
+        {
+            IType t = this.GetField(3, rep);
+            ret = (CX)t;
         }
-    } catch (HL7Exception he) {
-        HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
-        throw new System.Exception("An unexpected error ocurred", he);
-    } catch (System.Exception cce) {
-        HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
-        throw new System.Exception("An unexpected error ocurred", cce);
-  }
- return ret;
-}
-
-  ///<summary>
-  /// Returns the total repetitions of Insurance Co Phone Number (IN1-7).
-   ///</summary>
-  public int InsuranceCoPhoneNumberRepetitionsUsed
-{
-get{
-    try {
-	return GetTotalFieldRepetitionsUsed(7);
+        catch (System.Exception ex)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
+            throw new System.Exception("An unexpected error ocurred", ex);
+        }
+        return ret;
     }
-catch (HL7Exception he) {
-        HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
-        throw new System.Exception("An unexpected error ocurred", he);
-} catch (System.Exception cce) {
-        HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
-        throw new System.Exception("An unexpected error ocurred", cce);
-}
-}
-}
-	///<summary>
-	/// Returns Group Number(IN1-8).
-	///</summary>
-	public ST GroupNumber
+
+
+    ///<summary>
+    /// Returns all repetitions of Insurance Company ID(IN1-3).
+    ///</summary>
+    public CX[] GetInsuranceCompanyID()
+    {
+        CX[] ret = null;
+        try
+        {
+            IType[] t = this.GetField(3);
+            ret = new CX[t.Length];
+            for (int i = 0; i < ret.Length; i++)
+            {
+                ret[i] = (CX)t[i];
+            }
+        }
+        catch (HL7Exception he)
+        {
+            HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+            throw new System.Exception("An unexpected error ocurred", he);
+        }
+        catch (System.Exception cce)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+            throw new System.Exception("An unexpected error ocurred", cce);
+        }
+        return ret;
+    }
+
+
+    ///<summary>
+    /// Returns the total repetitions of Insurance Company ID(IN1-3).
+    ///</summary>
+    public int InsuranceCompanyIDRepetitionsUsed
+    {
+        get
+        {
+            try
+            {
+                return GetTotalFieldRepetitionsUsed(3);
+            }
+            catch (HL7Exception he)
+            {
+                HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+                throw new System.Exception("An unexpected error ocurred", he);
+            }
+            catch (System.Exception cce)
+            {
+                HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+                throw new System.Exception("An unexpected error ocurred", cce);
+            }
+        }
+    }
+    ///<summary>
+    /// Returns a single repetition of Insurance Company Name(IN1-4).
+    /// throws HL7Exception if the repetition number is invalid.
+    /// <param name="rep">The repetition number (this is a repeating field)</param>
+    ///</summary>
+    public XON GetInsuranceCompanyName(int rep)
+    {
+        XON ret = null;
+        try
+        {
+            IType t = this.GetField(4, rep);
+            ret = (XON)t;
+        }
+        catch (System.Exception ex)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
+            throw new System.Exception("An unexpected error ocurred", ex);
+        }
+        return ret;
+    }
+
+
+    ///<summary>
+    /// Returns all repetitions of Insurance Company Name(IN1-4).
+    ///</summary>
+    public XON[] GetInsuranceCompanyName()
+    {
+        XON[] ret = null;
+        try
+        {
+            IType[] t = this.GetField(4);
+            ret = new XON[t.Length];
+            for (int i = 0; i < ret.Length; i++)
+            {
+                ret[i] = (XON)t[i];
+            }
+        }
+        catch (HL7Exception he)
+        {
+            HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+            throw new System.Exception("An unexpected error ocurred", he);
+        }
+        catch (System.Exception cce)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+            throw new System.Exception("An unexpected error ocurred", cce);
+        }
+        return ret;
+    }
+
+
+    ///<summary>
+    /// Returns the total repetitions of Insurance Company Name(IN1-4).
+    ///</summary>
+    public int InsuranceCompanyNameRepetitionsUsed
+    {
+        get
+        {
+            try
+            {
+                return GetTotalFieldRepetitionsUsed(4);
+            }
+            catch (HL7Exception he)
+            {
+                HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+                throw new System.Exception("An unexpected error ocurred", he);
+            }
+            catch (System.Exception cce)
+            {
+                HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+                throw new System.Exception("An unexpected error ocurred", cce);
+            }
+        }
+    }
+    ///<summary>
+    /// Returns a single repetition of Insurance Company Address(IN1-5).
+    /// throws HL7Exception if the repetition number is invalid.
+    /// <param name="rep">The repetition number (this is a repeating field)</param>
+    ///</summary>
+    public XAD GetInsuranceCompanyAddress(int rep)
+    {
+        XAD ret = null;
+        try
+        {
+            IType t = this.GetField(5, rep);
+            ret = (XAD)t;
+        }
+        catch (System.Exception ex)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
+            throw new System.Exception("An unexpected error ocurred", ex);
+        }
+        return ret;
+    }
+
+
+    ///<summary>
+    /// Returns all repetitions of Insurance Company Address(IN1-5).
+    ///</summary>
+    public XAD[] GetInsuranceCompanyAddress()
+    {
+        XAD[] ret = null;
+        try
+        {
+            IType[] t = this.GetField(5);
+            ret = new XAD[t.Length];
+            for (int i = 0; i < ret.Length; i++)
+            {
+                ret[i] = (XAD)t[i];
+            }
+        }
+        catch (HL7Exception he)
+        {
+            HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+            throw new System.Exception("An unexpected error ocurred", he);
+        }
+        catch (System.Exception cce)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+            throw new System.Exception("An unexpected error ocurred", cce);
+        }
+        return ret;
+    }
+
+
+    ///<summary>
+    /// Returns the total repetitions of Insurance Company Address(IN1-5).
+    ///</summary>
+    public int InsuranceCompanyAddressRepetitionsUsed
+    {
+        get
+        {
+            try
+            {
+                return GetTotalFieldRepetitionsUsed(5);
+            }
+            catch (HL7Exception he)
+            {
+                HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+                throw new System.Exception("An unexpected error ocurred", he);
+            }
+            catch (System.Exception cce)
+            {
+                HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+                throw new System.Exception("An unexpected error ocurred", cce);
+            }
+        }
+    }
+    ///<summary>
+    /// Returns a single repetition of Insurance Co. Contact Person(IN1-6).
+    /// throws HL7Exception if the repetition number is invalid.
+    /// <param name="rep">The repetition number (this is a repeating field)</param>
+    ///</summary>
+    public XPN GetInsuranceCoContactPpers(int rep)
+    {
+        XPN ret = null;
+        try
+        {
+            IType t = this.GetField(6, rep);
+            ret = (XPN)t;
+        }
+        catch (System.Exception ex)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
+            throw new System.Exception("An unexpected error ocurred", ex);
+        }
+        return ret;
+    }
+
+
+    ///<summary>
+    /// Returns all repetitions of Insurance Co. Contact Person(IN1-6).
+    ///</summary>
+    public XPN[] GetInsuranceCoContactPpers()
+    {
+        XPN[] ret = null;
+        try
+        {
+            IType[] t = this.GetField(6);
+            ret = new XPN[t.Length];
+            for (int i = 0; i < ret.Length; i++)
+            {
+                ret[i] = (XPN)t[i];
+            }
+        }
+        catch (HL7Exception he)
+        {
+            HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+            throw new System.Exception("An unexpected error ocurred", he);
+        }
+        catch (System.Exception cce)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+            throw new System.Exception("An unexpected error ocurred", cce);
+        }
+        return ret;
+    }
+
+
+    ///<summary>
+    /// Returns the total repetitions of Insurance Co. Contact Person(IN1-6).
+    ///</summary>
+    public int InsuranceCoContactPpersRepetitionsUsed
+    {
+        get
+        {
+            try
+            {
+                return GetTotalFieldRepetitionsUsed(6);
+            }
+            catch (HL7Exception he)
+            {
+                HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+                throw new System.Exception("An unexpected error ocurred", he);
+            }
+            catch (System.Exception cce)
+            {
+                HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+                throw new System.Exception("An unexpected error ocurred", cce);
+            }
+        }
+    }
+    ///<summary>
+    /// Returns a single repetition of Insurance Co Phone Number(IN1-7).
+    /// throws HL7Exception if the repetition number is invalid.
+    /// <param name="rep">The repetition number (this is a repeating field)</param>
+    ///</summary>
+    public XTN GetInsuranceCoPhoneNumber(int rep)
+    {
+        XTN ret = null;
+        try
+        {
+            IType t = this.GetField(7, rep);
+            ret = (XTN)t;
+        }
+        catch (System.Exception ex)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
+            throw new System.Exception("An unexpected error ocurred", ex);
+        }
+        return ret;
+    }
+
+
+    ///<summary>
+    /// Returns all repetitions of Insurance Co Phone Number(IN1-7).
+    ///</summary>
+    public XTN[] GetInsuranceCoPhoneNumber()
+    {
+        XTN[] ret = null;
+        try
+        {
+            IType[] t = this.GetField(7);
+            ret = new XTN[t.Length];
+            for (int i = 0; i < ret.Length; i++)
+            {
+                ret[i] = (XTN)t[i];
+            }
+        }
+        catch (HL7Exception he)
+        {
+            HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+            throw new System.Exception("An unexpected error ocurred", he);
+        }
+        catch (System.Exception cce)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+            throw new System.Exception("An unexpected error ocurred", cce);
+        }
+        return ret;
+    }
+
+    ///<summary>
+    /// Returns the total repetitions of Insurance Co Phone Number(IN1-7).
+    ///</summary>
+    public int InsuranceCoPhoneNumberRepetitionsUsed
+    {
+        get
+        {
+            try
+            {
+                return GetTotalFieldRepetitionsUsed(7);
+            }
+            catch (HL7Exception he)
+            {
+                HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+                throw new System.Exception("An unexpected error ocurred", he);
+            }
+            catch (System.Exception cce)
+            {
+                HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+                throw new System.Exception("An unexpected error ocurred", cce);
+            }
+        }
+    }
+
+        ///<summary>
+        /// Returns Group Number(IN1-8).
+        ///</summary>
+        public ST GroupNumber
 	{
 		get{
 			ST ret = null;
@@ -349,79 +569,232 @@ catch (HL7Exception he) {
 	}
   }
 
-	///<summary>
-	/// Returns Group Name(IN1-9).
-	///</summary>
-	public XON GroupName
-	{
-		get{
-			XON ret = null;
-			try
-			{
-			IType t = this.GetField(9, 0);
-				ret = (XON)t;
-			}
-			 catch (HL7Exception he) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
-				throw new System.Exception("An unexpected error ocurred", he);
-		} catch (System.Exception ex) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
-				throw new System.Exception("An unexpected error ocurred", ex);
+    ///<summary>
+    /// Returns a single repetition of Group Name(IN1-9).
+    /// throws HL7Exception if the repetition number is invalid.
+    /// <param name="rep">The repetition number (this is a repeating field)</param>
+    ///</summary>
+    public XON GetGroupName(int rep)
+    {
+        XON ret = null;
+        try
+        {
+            IType t = this.GetField(9, rep);
+            ret = (XON)t;
+        }
+        catch (System.Exception ex)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
+            throw new System.Exception("An unexpected error ocurred", ex);
+        }
+        return ret;
     }
-			return ret;
-	}
-  }
 
-	///<summary>
-	/// Returns Insured's group employer ID(IN1-10).
-	///</summary>
-	public CX InsuredSGroupEmployerID
-	{
-		get{
-			CX ret = null;
-			try
-			{
-			IType t = this.GetField(10, 0);
-				ret = (CX)t;
-			}
-			 catch (HL7Exception he) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
-				throw new System.Exception("An unexpected error ocurred", he);
-		} catch (System.Exception ex) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
-				throw new System.Exception("An unexpected error ocurred", ex);
+
+    ///<summary>
+    /// Returns all repetitions of Group Name(IN1-9).
+    ///</summary>
+    public XON[] GetGroupName()
+    {
+        XON[] ret = null;
+        try
+        {
+            IType[] t = this.GetField(9);
+            ret = new XON[t.Length];
+            for (int i = 0; i < ret.Length; i++)
+            {
+                ret[i] = (XON)t[i];
+            }
+        }
+        catch (HL7Exception he)
+        {
+            HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+            throw new System.Exception("An unexpected error ocurred", he);
+        }
+        catch (System.Exception cce)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+            throw new System.Exception("An unexpected error ocurred", cce);
+        }
+        return ret;
     }
-			return ret;
-	}
-  }
 
-	///<summary>
-	/// Returns Insured's Group Emp Name(IN1-11).
-	///</summary>
-	public XON InsuredSGroupEmpName
-	{
-		get{
-			XON ret = null;
-			try
-			{
-			IType t = this.GetField(11, 0);
-				ret = (XON)t;
-			}
-			 catch (HL7Exception he) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
-				throw new System.Exception("An unexpected error ocurred", he);
-		} catch (System.Exception ex) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
-				throw new System.Exception("An unexpected error ocurred", ex);
+
+    ///<summary>
+    /// Returns the total repetitions of Group Name(IN1-9).
+    ///</summary>
+    public int GroupNameRepetitionsUsed
+    {
+        get
+        {
+            try
+            {
+                return GetTotalFieldRepetitionsUsed(9);
+            }
+            catch (HL7Exception he)
+            {
+                HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+                throw new System.Exception("An unexpected error ocurred", he);
+            }
+            catch (System.Exception cce)
+            {
+                HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+                throw new System.Exception("An unexpected error ocurred", cce);
+            }
+        }
     }
-			return ret;
-	}
-  }
+    ///<summary>
+    /// Returns a single repetition of Insured's group employer ID(IN1-10).
+    /// throws HL7Exception if the repetition number is invalid.
+    /// <param name="rep">The repetition number (this is a repeating field)</param>
+    ///</summary>
+    public CX GetInsuredSGroupEmployerID(int rep)
+    {
+        CX ret = null;
+        try
+        {
+            IType t = this.GetField(10, rep);
+            ret = (CX)t;
+        }
+        catch (System.Exception ex)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
+            throw new System.Exception("An unexpected error ocurred", ex);
+        }
+        return ret;
+    }
 
-	///<summary>
-	/// Returns Plan Effective Date(IN1-12).
-	///</summary>
-	public DT PlanEffectiveDate
+
+    ///<summary>
+    /// Returns all repetitions of Insured's group employer ID(IN1-10).
+    ///</summary>
+    public CX[] GetInsuredSGroupEmployerID()
+    {
+        CX[] ret = null;
+        try
+        {
+            IType[] t = this.GetField(10);
+            ret = new CX[t.Length];
+            for (int i = 0; i < ret.Length; i++)
+            {
+                ret[i] = (CX)t[i];
+            }
+        }
+        catch (HL7Exception he)
+        {
+            HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+            throw new System.Exception("An unexpected error ocurred", he);
+        }
+        catch (System.Exception cce)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+            throw new System.Exception("An unexpected error ocurred", cce);
+        }
+        return ret;
+    }
+
+
+    ///<summary>
+    /// Returns the total repetitions of Insured's group employer ID(IN1-10).
+    ///</summary>
+    public int InsuredSGroupEmployerIDRepetitionsUsed
+    {
+        get
+        {
+            try
+            {
+                return GetTotalFieldRepetitionsUsed(10);
+            }
+            catch (HL7Exception he)
+            {
+                HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+                throw new System.Exception("An unexpected error ocurred", he);
+            }
+            catch (System.Exception cce)
+            {
+                HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+                throw new System.Exception("An unexpected error ocurred", cce);
+            }
+        }
+    }
+    ///<summary>
+    /// Returns a single repetition of Insured's Group Emp Name(IN1-11).
+    /// throws HL7Exception if the repetition number is invalid.
+    /// <param name="rep">The repetition number (this is a repeating field)</param>
+    ///</summary>
+    public XON GetInsuredSGroupEmpName(int rep)
+    {
+        XON ret = null;
+        try
+        {
+            IType t = this.GetField(11, rep);
+            ret = (XON)t;
+        }
+        catch (System.Exception ex)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
+            throw new System.Exception("An unexpected error ocurred", ex);
+        }
+        return ret;
+    }
+
+
+    ///<summary>
+    /// Returns all repetitions of Insured's Group Emp Name(IN1-11).
+    ///</summary>
+    public XON[] GetInsuredSGroupEmpName()
+    {
+        XON[] ret = null;
+        try
+        {
+            IType[] t = this.GetField(11);
+            ret = new XON[t.Length];
+            for (int i = 0; i < ret.Length; i++)
+            {
+                ret[i] = (XON)t[i];
+            }
+        }
+        catch (HL7Exception he)
+        {
+            HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+            throw new System.Exception("An unexpected error ocurred", he);
+        }
+        catch (System.Exception cce)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+            throw new System.Exception("An unexpected error ocurred", cce);
+        }
+        return ret;
+    }
+
+
+    ///<summary>
+    /// Returns the total repetitions of Insured's Group Emp Name(IN1-11).
+    ///</summary>
+    public int InsuredSGroupEmpNameRepetitionsUsed
+    {
+        get
+        {
+            try
+            {
+                return GetTotalFieldRepetitionsUsed(11);
+            }
+            catch (HL7Exception he)
+            {
+                HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+                throw new System.Exception("An unexpected error ocurred", he);
+            }
+            catch (System.Exception cce)
+            {
+                HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+                throw new System.Exception("An unexpected error ocurred", cce);
+            }
+        }
+    }
+    ///<summary>
+    /// Returns Plan Effective Date(IN1-12).
+    ///</summary>
+    public DT PlanEffectiveDate
 	{
 		get{
 			DT ret = null;
@@ -510,33 +883,85 @@ catch (HL7Exception he) {
 	}
   }
 
-	///<summary>
-	/// Returns Name of Insured(IN1-16).
-	///</summary>
-	public XPN NameOfInsured
-	{
-		get{
-			XPN ret = null;
-			try
-			{
-			IType t = this.GetField(16, 0);
-				ret = (XPN)t;
-			}
-			 catch (HL7Exception he) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
-				throw new System.Exception("An unexpected error ocurred", he);
-		} catch (System.Exception ex) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
-				throw new System.Exception("An unexpected error ocurred", ex);
+    ///<summary>
+    /// Returns a single repetition of Name of Insured(IN1-16).
+    /// throws HL7Exception if the repetition number is invalid.
+    /// <param name="rep">The repetition number (this is a repeating field)</param>
+    ///</summary>
+    public XPN GetNameOfInsured(int rep)
+    {
+        XPN ret = null;
+        try
+        {
+            IType t = this.GetField(16, rep);
+            ret = (XPN)t;
+        }
+        catch (System.Exception ex)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
+            throw new System.Exception("An unexpected error ocurred", ex);
+        }
+        return ret;
     }
-			return ret;
-	}
-  }
 
-	///<summary>
-	/// Returns Insured's Relationship to Patient(IN1-17).
-	///</summary>
-	public IS InsuredSRelationshipToPatient
+
+    ///<summary>
+    /// Returns all repetitions of Name of Insured(IN1-16).
+    ///</summary>
+    public XPN[] GetNameOfInsured()
+    {
+        XPN[] ret = null;
+        try
+        {
+            IType[] t = this.GetField(16);
+            ret = new XPN[t.Length];
+            for (int i = 0; i < ret.Length; i++)
+            {
+                ret[i] = (XPN)t[i];
+            }
+        }
+        catch (HL7Exception he)
+        {
+            HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+            throw new System.Exception("An unexpected error ocurred", he);
+        }
+        catch (System.Exception cce)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+            throw new System.Exception("An unexpected error ocurred", cce);
+        }
+        return ret;
+    }
+
+
+    ///<summary>
+    /// Returns the total repetitions of Name of Insured(IN1-16).
+    ///</summary>
+    public int NameOfInsuredRepetitionsUsed
+    {
+        get
+        {
+            try
+            {
+                return GetTotalFieldRepetitionsUsed(16);
+            }
+            catch (HL7Exception he)
+            {
+                HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+                throw new System.Exception("An unexpected error ocurred", he);
+            }
+            catch (System.Exception cce)
+            {
+                HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+                throw new System.Exception("An unexpected error ocurred", cce);
+            }
+        }
+    }
+
+        ///<summary>
+        /// Returns Insured's Relationship to Patient(IN1-17).
+        ///</summary>
+        public IS InsuredSRelationshipToPatient
 	{
 		get{
 			IS ret = null;
@@ -579,33 +1004,85 @@ catch (HL7Exception he) {
 	}
   }
 
-	///<summary>
-	/// Returns Insured's Address(IN1-19).
-	///</summary>
-	public XAD InsuredSAddress
-	{
-		get{
-			XAD ret = null;
-			try
-			{
-			IType t = this.GetField(19, 0);
-				ret = (XAD)t;
-			}
-			 catch (HL7Exception he) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
-				throw new System.Exception("An unexpected error ocurred", he);
-		} catch (System.Exception ex) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
-				throw new System.Exception("An unexpected error ocurred", ex);
+    ///<summary>
+    /// Returns a single repetition of Insured's Address(IN1-19).
+    /// throws HL7Exception if the repetition number is invalid.
+    /// <param name="rep">The repetition number (this is a repeating field)</param>
+    ///</summary>
+    public XAD GetInsuredSAddress(int rep)
+    {
+        XAD ret = null;
+        try
+        {
+            IType t = this.GetField(19, rep);
+            ret = (XAD)t;
+        }
+        catch (System.Exception ex)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
+            throw new System.Exception("An unexpected error ocurred", ex);
+        }
+        return ret;
     }
-			return ret;
-	}
-  }
 
-	///<summary>
-	/// Returns Assignment of Benefits(IN1-20).
-	///</summary>
-	public IS AssignmentOfBenefits
+
+    ///<summary>
+    /// Returns all repetitions of Insured's Address(IN1-19).
+    ///</summary>
+    public XAD[] GetInsuredSAddress()
+    {
+        XAD[] ret = null;
+        try
+        {
+            IType[] t = this.GetField(19);
+            ret = new XAD[t.Length];
+            for (int i = 0; i < ret.Length; i++)
+            {
+                ret[i] = (XAD)t[i];
+            }
+        }
+        catch (HL7Exception he)
+        {
+            HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+            throw new System.Exception("An unexpected error ocurred", he);
+        }
+        catch (System.Exception cce)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+            throw new System.Exception("An unexpected error ocurred", cce);
+        }
+        return ret;
+    }
+
+
+    ///<summary>
+    /// Returns the total repetitions of Insured's Address(IN1-19).
+    ///</summary>
+    public int InsuredSAddressRepetitionsUsed
+    {
+        get
+        {
+            try
+            {
+                return GetTotalFieldRepetitionsUsed(19);
+            }
+            catch (HL7Exception he)
+            {
+                HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+                throw new System.Exception("An unexpected error ocurred", he);
+            }
+            catch (System.Exception cce)
+            {
+                HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+                throw new System.Exception("An unexpected error ocurred", cce);
+            }
+        }
+    }
+
+        ///<summary>
+        /// Returns Assignment of Benefits(IN1-20).
+        ///</summary>
+        public IS AssignmentOfBenefits
 	{
 		get{
 			IS ret = null;
@@ -1154,33 +1631,85 @@ catch (HL7Exception he) {
 	}
   }
 
-	///<summary>
-	/// Returns Insured's Employer Address(IN1-44).
-	///</summary>
-	public XAD InsuredSEmployerAddress
-	{
-		get{
-			XAD ret = null;
-			try
-			{
-			IType t = this.GetField(44, 0);
-				ret = (XAD)t;
-			}
-			 catch (HL7Exception he) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
-				throw new System.Exception("An unexpected error ocurred", he);
-		} catch (System.Exception ex) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
-				throw new System.Exception("An unexpected error ocurred", ex);
+    ///<summary>
+    /// Returns a single repetition of Insured's Employer Address(IN1-44).
+    /// throws HL7Exception if the repetition number is invalid.
+    /// <param name="rep">The repetition number (this is a repeating field)</param>
+    ///</summary>
+    public XAD GetInsuredSEmployerAddress(int rep)
+    {
+        XAD ret = null;
+        try
+        {
+            IType t = this.GetField(44, rep);
+            ret = (XAD)t;
+        }
+        catch (System.Exception ex)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
+            throw new System.Exception("An unexpected error ocurred", ex);
+        }
+        return ret;
     }
-			return ret;
-	}
-  }
 
-	///<summary>
-	/// Returns Verification Status(IN1-45).
-	///</summary>
-	public ST VerificationStatus
+
+    ///<summary>
+    /// Returns all repetitions of Insured's Employer Address(IN1-44).
+    ///</summary>
+    public XAD[] GetInsuredSEmployerAddress()
+    {
+        XAD[] ret = null;
+        try
+        {
+            IType[] t = this.GetField(44);
+            ret = new XAD[t.Length];
+            for (int i = 0; i < ret.Length; i++)
+            {
+                ret[i] = (XAD)t[i];
+            }
+        }
+        catch (HL7Exception he)
+        {
+            HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+            throw new System.Exception("An unexpected error ocurred", he);
+        }
+        catch (System.Exception cce)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+            throw new System.Exception("An unexpected error ocurred", cce);
+        }
+        return ret;
+    }
+
+
+    ///<summary>
+    /// Returns the total repetitions of Insured's Employer Address(IN1-44).
+    ///</summary>
+    public int InsuredSEmployerAddressRepetitionsUsed
+    {
+        get
+        {
+            try
+            {
+                return GetTotalFieldRepetitionsUsed(44);
+            }
+            catch (HL7Exception he)
+            {
+                HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+                throw new System.Exception("An unexpected error ocurred", he);
+            }
+            catch (System.Exception cce)
+            {
+                HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+                throw new System.Exception("An unexpected error ocurred", cce);
+            }
+        }
+    }
+
+        ///<summary>
+        /// Returns Verification Status(IN1-45).
+        ///</summary>
+        public ST VerificationStatus
 	{
 		get{
 			ST ret = null;
@@ -1269,28 +1798,81 @@ catch (HL7Exception he) {
 	}
   }
 
-	///<summary>
-	/// Returns Insured's ID Number(IN1-49).
-	///</summary>
-	public CX InsuredSIDNumber
-	{
-		get{
-			CX ret = null;
-			try
-			{
-			IType t = this.GetField(49, 0);
-				ret = (CX)t;
-			}
-			 catch (HL7Exception he) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
-				throw new System.Exception("An unexpected error ocurred", he);
-		} catch (System.Exception ex) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
-				throw new System.Exception("An unexpected error ocurred", ex);
+    ///<summary>
+    /// Returns a single repetition of Insured's ID Number(IN1-49).
+    /// throws HL7Exception if the repetition number is invalid.
+    /// <param name="rep">The repetition number (this is a repeating field)</param>
+    ///</summary>
+    public CX GetInsuredSIDNumber(int rep)
+    {
+        CX ret = null;
+        try
+        {
+            IType t = this.GetField(49, rep);
+            ret = (CX)t;
+        }
+        catch (System.Exception ex)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
+            throw new System.Exception("An unexpected error ocurred", ex);
+        }
+        return ret;
     }
-			return ret;
-	}
-  }
 
 
-}}
+    ///<summary>
+    /// Returns all repetitions of Insured's ID Number(IN1-49).
+    ///</summary>
+    public CX[] GetInsuredSIDNumber()
+    {
+        CX[] ret = null;
+        try
+        {
+            IType[] t = this.GetField(49);
+            ret = new CX[t.Length];
+            for (int i = 0; i < ret.Length; i++)
+            {
+                ret[i] = (CX)t[i];
+            }
+        }
+        catch (HL7Exception he)
+        {
+            HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+            throw new System.Exception("An unexpected error ocurred", he);
+        }
+        catch (System.Exception cce)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+            throw new System.Exception("An unexpected error ocurred", cce);
+        }
+        return ret;
+    }
+
+
+    ///<summary>
+    /// Returns the total repetitions of Insured's ID Number(IN1-49).
+    ///</summary>
+    public int InsuredSIDNumberRepetitionsUsed
+    {
+        get
+        {
+            try
+            {
+                return GetTotalFieldRepetitionsUsed(49);
+            }
+            catch (HL7Exception he)
+            {
+                HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+                throw new System.Exception("An unexpected error ocurred", he);
+            }
+            catch (System.Exception cce)
+            {
+                HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+                throw new System.Exception("An unexpected error ocurred", cce);
+            }
+        }
+    }
+
+
+    }
+}

--- a/src/NHapi.Model.V23/Segment/IN2.cs
+++ b/src/NHapi.Model.V23/Segment/IN2.cs
@@ -33,7 +33,7 @@ namespace NHapi.Model.V23.Segment{
 ///<li>IN2-21: Blood Deductible (ST)</li>
 ///<li>IN2-22: Special Coverage Approval Name (XPN)</li>
 ///<li>IN2-23: Special Coverage Approval Title (ST)</li>
-///<li>IN2-24: Non-Covered Insurance Code (ST)</li>
+///<li>IN2-24: Non-Covered Insurance Code (IS)</li>
 ///<li>IN2-25: Payor ID (CX)</li>
 ///<li>IN2-26: Payor Subscriber ID (CX)</li>
 ///<li>IN2-27: Eligibility Source (IS)</li>
@@ -99,15 +99,15 @@ public class IN2 : AbstractSegment  {
 	public IN2(IGroup parent, IModelClassFactory factory) : base(parent,factory) {
 	IMessage message = Message;
     try {
-       this.add(typeof(CX), false, 1, 59, new System.Object[]{message}, "Insured's Employee ID");
+       this.add(typeof(CX), false, 0, 59, new System.Object[]{message}, "Insured's Employee ID");
        this.add(typeof(ST), false, 1, 11, new System.Object[]{message}, "Insured's Social Security Number");
-       this.add(typeof(XCN), false, 1, 130, new System.Object[]{message}, "Insured's Employer Name");
+       this.add(typeof(XCN), false, 0, 130, new System.Object[]{message}, "Insured's Employer Name");
        this.add(typeof(IS), false, 1, 1, new System.Object[]{message, 139}, "Employer Information Data");
-       this.add(typeof(IS), false, 1, 1, new System.Object[]{message, 137}, "Mail Claim Party");
+       this.add(typeof(IS), false, 0, 1, new System.Object[]{message, 137}, "Mail Claim Party");
        this.add(typeof(ST), false, 1, 15, new System.Object[]{message}, "Medicare Health Ins Card Number");
-       this.add(typeof(XPN), false, 1, 48, new System.Object[]{message}, "Medicaid Case Name");
+       this.add(typeof(XPN), false, 0, 48, new System.Object[]{message}, "Medicaid Case Name");
        this.add(typeof(ST), false, 1, 15, new System.Object[]{message}, "Medicaid Case Number");
-       this.add(typeof(XPN), false, 1, 48, new System.Object[]{message}, "Champus Sponsor Name");
+       this.add(typeof(XPN), false, 0, 48, new System.Object[]{message}, "Champus Sponsor Name");
        this.add(typeof(ST), false, 1, 20, new System.Object[]{message}, "Champus ID Number");
        this.add(typeof(CE), false, 1, 80, new System.Object[]{message}, "Dependent of Champus Recipient");
        this.add(typeof(ST), false, 1, 25, new System.Object[]{message}, "Champus Organization");
@@ -120,9 +120,9 @@ public class IN2 : AbstractSegment  {
        this.add(typeof(ID), false, 1, 1, new System.Object[]{message, 136}, "Baby Coverage");
        this.add(typeof(ID), false, 1, 1, new System.Object[]{message, 136}, "Combine Baby Bill");
        this.add(typeof(ST), false, 1, 1, new System.Object[]{message}, "Blood Deductible");
-       this.add(typeof(XPN), false, 1, 48, new System.Object[]{message}, "Special Coverage Approval Name");
+       this.add(typeof(XPN), false, 0, 48, new System.Object[]{message}, "Special Coverage Approval Name");
        this.add(typeof(ST), false, 1, 30, new System.Object[]{message}, "Special Coverage Approval Title");
-       this.add(typeof(ST), false, 0, 8, new System.Object[]{message}, "Non-Covered Insurance Code");
+       this.add(typeof(IS), false, 0, 8, new System.Object[]{message}, "Non-Covered Insurance Code");
        this.add(typeof(CX), false, 1, 59, new System.Object[]{message}, "Payor ID");
        this.add(typeof(CX), false, 1, 59, new System.Object[]{message}, "Payor Subscriber ID");
        this.add(typeof(IS), false, 1, 1, new System.Object[]{message, 144}, "Eligibility Source");
@@ -176,33 +176,85 @@ public class IN2 : AbstractSegment  {
     }
   }
 
-	///<summary>
-	/// Returns Insured's Employee ID(IN2-1).
-	///</summary>
-	public CX InsuredSEmployeeID
-	{
-		get{
-			CX ret = null;
-			try
-			{
-			IType t = this.GetField(1, 0);
-				ret = (CX)t;
-			}
-			 catch (HL7Exception he) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
-				throw new System.Exception("An unexpected error ocurred", he);
-		} catch (System.Exception ex) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
-				throw new System.Exception("An unexpected error ocurred", ex);
+    ///<summary>
+    /// Returns a single repetition of Insured's Employee ID(IN2-1).
+    /// throws HL7Exception if the repetition number is invalid.
+    /// <param name="rep">The repetition number (this is a repeating field)</param>
+    ///</summary>
+    public CX GetInsuredSEmployeeID(int rep)
+    {
+        CX ret = null;
+        try
+        {
+            IType t = this.GetField(1, rep);
+            ret = (CX)t;
+        }
+        catch (System.Exception ex)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
+            throw new System.Exception("An unexpected error ocurred", ex);
+        }
+        return ret;
     }
-			return ret;
-	}
-  }
 
-	///<summary>
-	/// Returns Insured's Social Security Number(IN2-2).
-	///</summary>
-	public ST InsuredSSocialSecurityNumber
+
+    ///<summary>
+    /// Returns all repetitions of Insured's Employee ID(IN2-1).
+    ///</summary>
+    public CX[] GetInsuredSEmployeeID()
+    {
+        CX[] ret = null;
+        try
+        {
+            IType[] t = this.GetField(1);
+            ret = new CX[t.Length];
+            for (int i = 0; i < ret.Length; i++)
+            {
+                ret[i] = (CX)t[i];
+            }
+        }
+        catch (HL7Exception he)
+        {
+            HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+            throw new System.Exception("An unexpected error ocurred", he);
+        }
+        catch (System.Exception cce)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+            throw new System.Exception("An unexpected error ocurred", cce);
+        }
+        return ret;
+    }
+
+
+    ///<summary>
+    /// Returns the total repetitions of Insured's Employee ID(IN2-1).
+    ///</summary>
+    public int InsuredSEmployeeIDRepetitionsUsed
+    {
+        get
+        {
+            try
+            {
+                return GetTotalFieldRepetitionsUsed(1);
+            }
+            catch (HL7Exception he)
+            {
+                HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+                throw new System.Exception("An unexpected error ocurred", he);
+            }
+            catch (System.Exception cce)
+            {
+                HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+                throw new System.Exception("An unexpected error ocurred", cce);
+            }
+        }
+    }
+
+        ///<summary>
+        /// Returns Insured's Social Security Number(IN2-2).
+        ///</summary>
+        public ST InsuredSSocialSecurityNumber
 	{
 		get{
 			ST ret = null;
@@ -222,33 +274,85 @@ public class IN2 : AbstractSegment  {
 	}
   }
 
-	///<summary>
-	/// Returns Insured's Employer Name(IN2-3).
-	///</summary>
-	public XCN InsuredSEmployerName
-	{
-		get{
-			XCN ret = null;
-			try
-			{
-			IType t = this.GetField(3, 0);
-				ret = (XCN)t;
-			}
-			 catch (HL7Exception he) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
-				throw new System.Exception("An unexpected error ocurred", he);
-		} catch (System.Exception ex) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
-				throw new System.Exception("An unexpected error ocurred", ex);
+    ///<summary>
+    /// Returns a single repetition of Insured's Employer Name(IN2-3).
+    /// throws HL7Exception if the repetition number is invalid.
+    /// <param name="rep">The repetition number (this is a repeating field)</param>
+    ///</summary>
+    public XCN GetInsuredSEmployerName(int rep)
+    {
+        XCN ret = null;
+        try
+        {
+            IType t = this.GetField(3, rep);
+            ret = (XCN)t;
+        }
+        catch (System.Exception ex)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
+            throw new System.Exception("An unexpected error ocurred", ex);
+        }
+        return ret;
     }
-			return ret;
-	}
-  }
 
-	///<summary>
-	/// Returns Employer Information Data(IN2-4).
-	///</summary>
-	public IS EmployerInformationData
+
+    ///<summary>
+    /// Returns all repetitions of Insured's Employer Name(IN2-3).
+    ///</summary>
+    public XCN[] GetInsuredSEmployerName()
+    {
+        XCN[] ret = null;
+        try
+        {
+            IType[] t = this.GetField(3);
+            ret = new XCN[t.Length];
+            for (int i = 0; i < ret.Length; i++)
+            {
+                ret[i] = (XCN)t[i];
+            }
+        }
+        catch (HL7Exception he)
+        {
+            HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+            throw new System.Exception("An unexpected error ocurred", he);
+        }
+        catch (System.Exception cce)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+            throw new System.Exception("An unexpected error ocurred", cce);
+        }
+        return ret;
+    }
+
+
+    ///<summary>
+    /// Returns the total repetitions of Insured's Employer Name(IN2-3).
+    ///</summary>
+    public int InsuredSEmployerNameRepetitionsUsed
+    {
+        get
+        {
+            try
+            {
+                return GetTotalFieldRepetitionsUsed(3);
+            }
+            catch (HL7Exception he)
+            {
+                HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+                throw new System.Exception("An unexpected error ocurred", he);
+            }
+            catch (System.Exception cce)
+            {
+                HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+                throw new System.Exception("An unexpected error ocurred", cce);
+            }
+        }
+    }
+
+    ///<summary>
+    /// Returns Employer Information Data(IN2-4).
+    ///</summary>
+    public IS EmployerInformationData
 	{
 		get{
 			IS ret = null;
@@ -268,33 +372,85 @@ public class IN2 : AbstractSegment  {
 	}
   }
 
-	///<summary>
-	/// Returns Mail Claim Party(IN2-5).
-	///</summary>
-	public IS MailClaimParty
-	{
-		get{
-			IS ret = null;
-			try
-			{
-			IType t = this.GetField(5, 0);
-				ret = (IS)t;
-			}
-			 catch (HL7Exception he) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
-				throw new System.Exception("An unexpected error ocurred", he);
-		} catch (System.Exception ex) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
-				throw new System.Exception("An unexpected error ocurred", ex);
+    ///<summary>
+    /// Returns a single repetition of Mail Claim Party(IN2-5).
+    /// throws HL7Exception if the repetition number is invalid.
+    /// <param name="rep">The repetition number (this is a repeating field)</param>
+    ///</summary>
+    public IS GetMailClaimParty(int rep)
+    {
+        IS ret = null;
+        try
+        {
+            IType t = this.GetField(5, rep);
+            ret = (IS)t;
+        }
+        catch (System.Exception ex)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
+            throw new System.Exception("An unexpected error ocurred", ex);
+        }
+        return ret;
     }
-			return ret;
-	}
-  }
 
-	///<summary>
-	/// Returns Medicare Health Ins Card Number(IN2-6).
-	///</summary>
-	public ST MedicareHealthInsCardNumber
+
+    ///<summary>
+    /// Returns all repetitions of Mail Claim Party(IN2-5).
+    ///</summary>
+    public IS[] GetMailClaimParty()
+    {
+        IS[] ret = null;
+        try
+        {
+            IType[] t = this.GetField(5);
+            ret = new IS[t.Length];
+            for (int i = 0; i < ret.Length; i++)
+            {
+                ret[i] = (IS)t[i];
+            }
+        }
+        catch (HL7Exception he)
+        {
+            HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+            throw new System.Exception("An unexpected error ocurred", he);
+        }
+        catch (System.Exception cce)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+            throw new System.Exception("An unexpected error ocurred", cce);
+        }
+        return ret;
+    }
+
+
+    ///<summary>
+    /// Returns the total repetitions of Mail Claim Party(IN2-5).
+    ///</summary>
+    public int MailClaimPartyRepetitionsUsed
+    {
+        get
+        {
+            try
+            {
+                return GetTotalFieldRepetitionsUsed(5);
+            }
+            catch (HL7Exception he)
+            {
+                HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+                throw new System.Exception("An unexpected error ocurred", he);
+            }
+            catch (System.Exception cce)
+            {
+                HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+                throw new System.Exception("An unexpected error ocurred", cce);
+            }
+        }
+    }
+
+        ///<summary>
+        /// Returns Medicare Health Ins Card Number(IN2-6).
+        ///</summary>
+        public ST MedicareHealthInsCardNumber
 	{
 		get{
 			ST ret = null;
@@ -314,33 +470,84 @@ public class IN2 : AbstractSegment  {
 	}
   }
 
-	///<summary>
-	/// Returns Medicaid Case Name(IN2-7).
-	///</summary>
-	public XPN MedicaidCaseName
-	{
-		get{
-			XPN ret = null;
-			try
-			{
-			IType t = this.GetField(7, 0);
-				ret = (XPN)t;
-			}
-			 catch (HL7Exception he) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
-				throw new System.Exception("An unexpected error ocurred", he);
-		} catch (System.Exception ex) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
-				throw new System.Exception("An unexpected error ocurred", ex);
+    ///<summary>
+    /// Returns a single repetition of Medicaid Case Name(IN2-7).
+    /// throws HL7Exception if the repetition number is invalid.
+    /// <param name="rep">The repetition number (this is a repeating field)</param>
+    ///</summary>
+    public XPN GetMedicaidCaseName(int rep)
+    {
+        XPN ret = null;
+        try
+        {
+            IType t = this.GetField(7, rep);
+            ret = (XPN)t;
+        }
+        catch (System.Exception ex)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
+            throw new System.Exception("An unexpected error ocurred", ex);
+        }
+        return ret;
     }
-			return ret;
-	}
-  }
 
-	///<summary>
-	/// Returns Medicaid Case Number(IN2-8).
-	///</summary>
-	public ST MedicaidCaseNumber
+
+    ///<summary>
+    /// Returns all repetitions of Medicaid Case Name(IN2-7).
+    ///</summary>
+    public XPN[] GetMedicaidCaseName()
+    {
+        XPN[] ret = null;
+        try
+        {
+            IType[] t = this.GetField(7);
+            ret = new XPN[t.Length];
+            for (int i = 0; i < ret.Length; i++)
+            {
+                ret[i] = (XPN)t[i];
+            }
+        }
+        catch (HL7Exception he)
+        {
+            HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+            throw new System.Exception("An unexpected error ocurred", he);
+        }
+        catch (System.Exception cce)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+            throw new System.Exception("An unexpected error ocurred", cce);
+        }
+        return ret;
+    }
+
+
+    ///<summary>
+    /// Returns the total repetitions of Medicaid Case Name(IN2-7).
+    ///</summary>
+    public int MedicaidCaseNameRepetitionsUsed
+    {
+        get
+        {
+            try
+            {
+                return GetTotalFieldRepetitionsUsed(7);
+            }
+            catch (HL7Exception he)
+            {
+                HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+                throw new System.Exception("An unexpected error ocurred", he);
+            }
+            catch (System.Exception cce)
+            {
+                HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+                throw new System.Exception("An unexpected error ocurred", cce);
+            }
+        }
+    }
+        ///<summary>
+        /// Returns Medicaid Case Number(IN2-8).
+        ///</summary>
+        public ST MedicaidCaseNumber
 	{
 		get{
 			ST ret = null;
@@ -360,33 +567,85 @@ public class IN2 : AbstractSegment  {
 	}
   }
 
-	///<summary>
-	/// Returns Champus Sponsor Name(IN2-9).
-	///</summary>
-	public XPN ChampusSponsorName
-	{
-		get{
-			XPN ret = null;
-			try
-			{
-			IType t = this.GetField(9, 0);
-				ret = (XPN)t;
-			}
-			 catch (HL7Exception he) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
-				throw new System.Exception("An unexpected error ocurred", he);
-		} catch (System.Exception ex) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
-				throw new System.Exception("An unexpected error ocurred", ex);
+    ///<summary>
+    /// Returns a single repetition of Champus Sponsor Name(IN2-9).
+    /// throws HL7Exception if the repetition number is invalid.
+    /// <param name="rep">The repetition number (this is a repeating field)</param>
+    ///</summary>
+    public XPN GetChampusSponsorName(int rep)
+    {
+        XPN ret = null;
+        try
+        {
+            IType t = this.GetField(9, rep);
+            ret = (XPN)t;
+        }
+        catch (System.Exception ex)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
+            throw new System.Exception("An unexpected error ocurred", ex);
+        }
+        return ret;
     }
-			return ret;
-	}
-  }
 
-	///<summary>
-	/// Returns Champus ID Number(IN2-10).
-	///</summary>
-	public ST ChampusIDNumber
+
+    ///<summary>
+    /// Returns all repetitions of Champus Sponsor Name(IN2-9).
+    ///</summary>
+    public XPN[] GetChampusSponsorName()
+    {
+        XPN[] ret = null;
+        try
+        {
+            IType[] t = this.GetField(9);
+            ret = new XPN[t.Length];
+            for (int i = 0; i < ret.Length; i++)
+            {
+                ret[i] = (XPN)t[i];
+            }
+        }
+        catch (HL7Exception he)
+        {
+            HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+            throw new System.Exception("An unexpected error ocurred", he);
+        }
+        catch (System.Exception cce)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+            throw new System.Exception("An unexpected error ocurred", cce);
+        }
+        return ret;
+    }
+
+
+    ///<summary>
+    /// Returns the total repetitions of Champus Sponsor Name(IN2-9).
+    ///</summary>
+    public int ChampusSponsorNameRepetitionsUsed
+    {
+        get
+        {
+            try
+            {
+                return GetTotalFieldRepetitionsUsed(9);
+            }
+            catch (HL7Exception he)
+            {
+                HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+                throw new System.Exception("An unexpected error ocurred", he);
+            }
+            catch (System.Exception cce)
+            {
+                HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+                throw new System.Exception("An unexpected error ocurred", cce);
+            }
+        }
+    }
+
+        ///<summary>
+        /// Returns Champus ID Number(IN2-10).
+        ///</summary>
+        public ST ChampusIDNumber
 	{
 		get{
 			ST ret = null;
@@ -659,33 +918,85 @@ public class IN2 : AbstractSegment  {
 	}
   }
 
-	///<summary>
-	/// Returns Special Coverage Approval Name(IN2-22).
-	///</summary>
-	public XPN SpecialCoverageApprovalName
-	{
-		get{
-			XPN ret = null;
-			try
-			{
-			IType t = this.GetField(22, 0);
-				ret = (XPN)t;
-			}
-			 catch (HL7Exception he) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
-				throw new System.Exception("An unexpected error ocurred", he);
-		} catch (System.Exception ex) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
-				throw new System.Exception("An unexpected error ocurred", ex);
+    ///<summary>
+    /// Returns a single repetition of Special Coverage Approval Name(IN2-22).
+    /// throws HL7Exception if the repetition number is invalid.
+    /// <param name="rep">The repetition number (this is a repeating field)</param>
+    ///</summary>
+    public XPN GetSpecialCoverageApprovalName(int rep)
+    {
+        XPN ret = null;
+        try
+        {
+            IType t = this.GetField(22, rep);
+            ret = (XPN)t;
+        }
+        catch (System.Exception ex)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
+            throw new System.Exception("An unexpected error ocurred", ex);
+        }
+        return ret;
     }
-			return ret;
-	}
-  }
 
-	///<summary>
-	/// Returns Special Coverage Approval Title(IN2-23).
-	///</summary>
-	public ST SpecialCoverageApprovalTitle
+
+    ///<summary>
+    /// Returns all repetitions of Special Coverage Approval Name(IN2-22).
+    ///</summary>
+    public XPN[] GetSpecialCoverageApprovalName()
+    {
+        XPN[] ret = null;
+        try
+        {
+            IType[] t = this.GetField(22);
+            ret = new XPN[t.Length];
+            for (int i = 0; i < ret.Length; i++)
+            {
+                ret[i] = (XPN)t[i];
+            }
+        }
+        catch (HL7Exception he)
+        {
+            HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+            throw new System.Exception("An unexpected error ocurred", he);
+        }
+        catch (System.Exception cce)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+            throw new System.Exception("An unexpected error ocurred", cce);
+        }
+        return ret;
+    }
+
+
+    ///<summary>
+    /// Returns the total repetitions of Special Coverage Approval Name(IN2-22).
+    ///</summary>
+    public int SpecialCoverageApprovalNameRepetitionsUsed
+    {
+        get
+        {
+            try
+            {
+                return GetTotalFieldRepetitionsUsed(22);
+            }
+            catch (HL7Exception he)
+            {
+                HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+                throw new System.Exception("An unexpected error ocurred", he);
+            }
+            catch (System.Exception cce)
+            {
+                HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+                throw new System.Exception("An unexpected error ocurred", cce);
+            }
+        }
+    }
+
+        ///<summary>
+        /// Returns Special Coverage Approval Title(IN2-23).
+        ///</summary>
+        public ST SpecialCoverageApprovalTitle
 	{
 		get{
 			ST ret = null;
@@ -705,68 +1016,87 @@ public class IN2 : AbstractSegment  {
 	}
   }
 
-	///<summary>
-	/// Returns a single repetition of Non-Covered Insurance Code(IN2-24).
-	/// throws HL7Exception if the repetition number is invalid.
-	/// <param name="rep">The repetition number (this is a repeating field)</param>
-	///</summary>
-	public ST GetNonCoveredInsuranceCode(int rep)
-	{
-			ST ret = null;
-			try
-			{
-			IType t = this.GetField(24, rep);
-				ret = (ST)t;
-		} catch (System.Exception ex) {
-			HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
-				throw new System.Exception("An unexpected error ocurred", ex);
-    }
-			return ret;
-  }
 
-  ///<summary>
-  /// Returns all repetitions of Non-Covered Insurance Code (IN2-24).
-   ///</summary>
-  public ST[] GetNonCoveredInsuranceCode() {
-     ST[] ret = null;
-    try {
-        IType[] t = this.GetField(24);  
-        ret = new ST[t.Length];
-        for (int i = 0; i < ret.Length; i++) {
-            ret[i] = (ST)t[i];
+    ///<summary>
+    /// Returns a single repetition of Non-Covered Insurance Code(IN2-24).
+    /// throws HL7Exception if the repetition number is invalid.
+    /// <param name="rep">The repetition number (this is a repeating field)</param>
+    ///</summary>
+    public IS GetNonCoveredInsuranceCode(int rep)
+    {
+        IS ret = null;
+        try
+        {
+            IType t = this.GetField(24, rep);
+            ret = (IS)t;
         }
-    } catch (HL7Exception he) {
-        HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
-        throw new System.Exception("An unexpected error ocurred", he);
-    } catch (System.Exception cce) {
-        HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
-        throw new System.Exception("An unexpected error ocurred", cce);
-  }
- return ret;
-}
-
-  ///<summary>
-  /// Returns the total repetitions of Non-Covered Insurance Code (IN2-24).
-   ///</summary>
-  public int NonCoveredInsuranceCodeRepetitionsUsed
-{
-get{
-    try {
-	return GetTotalFieldRepetitionsUsed(24);
+        catch (System.Exception ex)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", ex);
+            throw new System.Exception("An unexpected error ocurred", ex);
+        }
+        return ret;
     }
-catch (HL7Exception he) {
-        HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
-        throw new System.Exception("An unexpected error ocurred", he);
-} catch (System.Exception cce) {
-        HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
-        throw new System.Exception("An unexpected error ocurred", cce);
-}
-}
-}
-	///<summary>
-	/// Returns Payor ID(IN2-25).
-	///</summary>
-	public CX PayorID
+
+
+    ///<summary>
+    /// Returns all repetitions of Non-Covered Insurance Code(IN2-24).
+    ///</summary>
+    public IS[] GetNonCoveredInsuranceCode()
+    {
+        IS[] ret = null;
+        try
+        {
+            IType[] t = this.GetField(24);
+            ret = new IS[t.Length];
+            for (int i = 0; i < ret.Length; i++)
+            {
+                ret[i] = (IS)t[i];
+            }
+        }
+        catch (HL7Exception he)
+        {
+            HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+            throw new System.Exception("An unexpected error ocurred", he);
+        }
+        catch (System.Exception cce)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+            throw new System.Exception("An unexpected error ocurred", cce);
+        }
+        return ret;
+    }
+
+
+    ///<summary>
+    /// Returns the total repetitions of Non-Covered Insurance Code(IN2-24).
+    ///</summary>
+    public int NonCoveredInsuranceCodeRepetitionsUsed
+    {
+        get
+        {
+            try
+            {
+                return GetTotalFieldRepetitionsUsed(24);
+            }
+            catch (HL7Exception he)
+            {
+                HapiLogFactory.GetHapiLog(this.GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", he);
+                throw new System.Exception("An unexpected error ocurred", he);
+            }
+            catch (System.Exception cce)
+            {
+                HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected problem obtaining field value.  This is a bug.", cce);
+                throw new System.Exception("An unexpected error ocurred", cce);
+            }
+        }
+    }
+
+
+        ///<summary>
+        /// Returns Payor ID(IN2-25).
+        ///</summary>
+        public CX PayorID
 	{
 		get{
 			CX ret = null;

--- a/tests/NHapi.NUnit/PipeParsingFixture23.cs
+++ b/tests/NHapi.NUnit/PipeParsingFixture23.cs
@@ -1,4 +1,4 @@
-namespace NHapi.NUnit
+﻿namespace NHapi.NUnit
 {
     using System;
     using System.Collections.Generic;
@@ -363,6 +363,111 @@ PID|1|935307^^^EUH MRN^MRN^EH01|25106376^^^TEC MRN~1781893^^^CLH MRN~935307^^^EU
                 var cx = adtA01.PID.GetAlternatePatientID(rep);
                 Console.WriteLine(cx.ID.Value);
             }
+        }
+
+        /// <summary>
+        /// https://github.com/nHapiNET/nHapi/issues/191.
+        /// </summary>
+        [Test]
+        public void TestIN1andIN2fieldRepetitions()
+        {
+            var message = @"MSH|^~\&|EMM|SKL|TOE|SKL|202102031237||ADT^A08|36711904|P|2.3|||||D||DE
+EVN|A08|202102031237|202102031027||KKLLNN||
+PID|1|1000|1000||Test^Max^^^^||19370609|F|||NoSuch Str. 20^^Luneburg^^21337^D^L||04131/9786438^^PH|||||||||||N||D|
+NK1|1|Fr.Test^|6^Tochter|^^^^|||||||||||U|^YYYYMMDDHHMMSS|||||||||||||||||^^^ORBIS^PN^^^^~^^^ORBIS^PI^^^^~^^^ORBIS^PT^^^^|||||
+IN1|1||102114819^^^^NII~17101^^^^NIIP~AOK_00044^^^^XX|Die Gesundheitskasse~Comp 2~Comp 3|Hans-Böckler-Allee 30^^Hannover^^30001^D^P~Street 2^^Berlin~Street 3^^Moscow|John^Peak~Kit^Fin|0413189314641^PRN^PH^^^04131^89314641^~^PRN^FX^^^^^||AOK^1^^^&gesetzliche Krankenkasse^^NII~AOK^1^^^^^U|9283~7766~786~77663|Org1~Org2|||||Test^Max^^^^~Testor^N~Testoff^J~Testior^Y||19370609|Wilhelm Str. 44^^Lüneburg^^21337^D^P~Best Str^^Berlin|||H|||||||||R|||||S890768688|||||||W|Addr1~Addr2|||||S8907^^^^^^^~S9999|
+IN2|1234^^^^AMA~4567^^^^LANR||^Fam1~^Fam2||P~G~E||FN1~FN2~FN3~FN4||SP1~SP2~SP3^Tomas|||||||||||||SpCov1~SpCov2|||||||^PC^100||||D  |||J|||||||||||||||||||||||||||041319786438||||||||
+ZBE|13033374^ORBIS|202102031027|202102031237|UPDATE|";
+            var parser = new PipeParser();
+
+            var m = parser.Parse(message);
+
+            var adtA08 = m as ADT_A01; // a08 is mapped to a01
+
+            Assert.IsNotNull(adtA08);
+
+            var in1_3 = adtA08.GetINSURANCE().IN1.GetInsuranceCompanyID();
+            Assert.AreEqual(in1_3.Length, 3);
+            Assert.AreEqual(in1_3[0].IdentifierTypeCode.Value, "NII");
+            Assert.AreEqual(in1_3[1].IdentifierTypeCode.Value, "NIIP");
+            Assert.AreEqual(in1_3[2].IdentifierTypeCode.Value, "XX");
+
+            var in1_4 = adtA08.GetINSURANCE().IN1.GetInsuranceCompanyName();
+            Assert.AreEqual(in1_4.Length, 3);
+            Assert.AreEqual(in1_4[2].OrganizationName.Value, "Comp 3");
+
+            var in1_5 = adtA08.GetINSURANCE().IN1.GetInsuranceCompanyAddress();
+            Assert.AreEqual(in1_5.Length, 3);
+            Assert.AreEqual(in1_5[0].City.Value, "Hannover");
+            Assert.AreEqual(in1_5[1].City.Value, "Berlin");
+            Assert.AreEqual(in1_5[2].City.Value, "Moscow");
+
+            var in1_6 = adtA08.GetINSURANCE().IN1.GetInsuranceCoContactPpers();
+            Assert.AreEqual(in1_6.Length, 2);
+            Assert.AreEqual(in1_6[0].GivenName.Value, "Peak");
+            Assert.AreEqual(in1_6[1].GivenName.Value, "Fin");
+
+            var in1_7 = adtA08.GetINSURANCE().IN1.GetInsuranceCoPhoneNumber();
+            Assert.AreEqual(in1_7.Length, 2);
+            Assert.AreEqual(in1_7[0].TelecommunicationEquipmentType.Value, "PH");
+            Assert.AreEqual(in1_7[1].TelecommunicationEquipmentType.Value, "FX");
+
+            var in1_9 = adtA08.GetINSURANCE().IN1.GetGroupName();
+            Assert.AreEqual(in1_9.Length, 2);
+            Assert.AreEqual(in1_9[0].IdentifierTypeCode.Value, "NII");
+            Assert.AreEqual(in1_9[1].IdentifierTypeCode.Value, "U");
+
+            var in1_10 = adtA08.GetINSURANCE().IN1.GetInsuredSGroupEmployerID();
+            Assert.AreEqual(in1_10.Length, 4);
+
+            var in1_11 = adtA08.GetINSURANCE().IN1.GetInsuredSGroupEmpName();
+            Assert.AreEqual(in1_11.Length, 2);
+
+            var in1_16 = adtA08.GetINSURANCE().IN1.GetNameOfInsured();
+            Assert.AreEqual(in1_16.Length, 4);
+            Assert.AreEqual(in1_16[3].GivenName.Value, "Y");
+
+            var in1_19 = adtA08.GetINSURANCE().IN1.GetInsuredSAddress();
+            Assert.AreEqual(in1_19.Length, 2);
+            Assert.AreEqual(in1_19[1].City.Value, "Berlin");
+
+            var in1_44 = adtA08.GetINSURANCE().IN1.GetInsuredSEmployerAddress();
+            Assert.AreEqual(in1_44.Length, 2);
+            Assert.AreEqual(in1_44[0].StreetAddress.Value, "Addr1");
+            Assert.AreEqual(in1_44[1].StreetAddress.Value, "Addr2");
+
+            var in1_49 = adtA08.GetINSURANCE().IN1.GetInsuredSIDNumber();
+            Assert.AreEqual(in1_49.Length, 2);
+            Assert.AreEqual(in1_49[0].ID.Value, "S8907");
+            Assert.AreEqual(in1_49[1].ID.Value, "S9999");
+
+            var in2_1 = adtA08.GetINSURANCE().IN2.GetInsuredSEmployeeID();
+            Assert.AreEqual(in2_1.Length, 2);
+            Assert.AreEqual(in2_1[0].IdentifierTypeCode.Value, "AMA");
+            Assert.AreEqual(in2_1[1].IdentifierTypeCode.Value, "LANR");
+
+            var in2_3 = adtA08.GetINSURANCE().IN2.GetInsuredSEmployerName();
+            Assert.AreEqual(in2_3.Length, 2);
+            Assert.AreEqual(in2_3[0].FamilyName.Value, "Fam1");
+            Assert.AreEqual(in2_3[1].FamilyName.Value, "Fam2");
+
+            var in2_5 = adtA08.GetINSURANCE().IN2.GetMailClaimParty();
+            Assert.AreEqual(in2_5.Length, 3);
+            Assert.AreEqual(in2_5[0].Value, "P");
+            Assert.AreEqual(in2_5[1].Value, "G");
+            Assert.AreEqual(in2_5[2].Value, "E");
+
+            var in2_7 = adtA08.GetINSURANCE().IN2.GetMedicaidCaseName();
+            Assert.AreEqual(in2_7.Length, 4);
+            Assert.AreEqual(in2_7[3].FamilyName.Value, "FN4");
+
+            var in2_9 = adtA08.GetINSURANCE().IN2.GetChampusSponsorName();
+            Assert.AreEqual(in2_9.Length, 3);
+            Assert.AreEqual(in2_9[2].GivenName.Value, "Tomas");
+
+            var in2_22 = adtA08.GetINSURANCE().IN2.GetSpecialCoverageApprovalName();
+            Assert.AreEqual(in2_22.Length, 2);
+            Assert.AreEqual(in2_22[1].FamilyName.Value, "SpCov2");
         }
 
         /// <summary>


### PR DESCRIPTION
Due to errors in normative database for HL7 v. 2.3, IN1 and IN2 segments had incorrect repetition flags