### PR TITLE
Fix first build via build/default.ps1

### DIFF
--- a/build/default.ps1
+++ b/build/default.ps1
@@ -26,6 +26,13 @@ properties {
 Task Default -depends Build
 
 Task Clean {
+    $distPath = "..\dist\"
+
+    If (!(test-path $distPath))
+    {
+        md $distPath
+    }
+
 	Remove-Item ..\dist\*.nupkg
     Remove-Item ..\dist\net35\*.* -ErrorAction Ignore
     Remove-Item ..\dist\netstandard2.0\*.* -ErrorAction Ignore

--- a/build/default.ps1
+++ b/build/default.ps1
@@ -26,14 +26,7 @@ properties {
 Task Default -depends Build
 
 Task Clean {
-    $distPath = "..\dist\"
-
-    If (!(test-path $distPath))
-    {
-        md $distPath
-    }
-
-	Remove-Item ..\dist\*.nupkg
+    Remove-Item ..\dist\*.nupkg -ErrorAction Ignore
     Remove-Item ..\dist\net35\*.* -ErrorAction Ignore
     Remove-Item ..\dist\netstandard2.0\*.* -ErrorAction Ignore
 


### PR DESCRIPTION
Given cleanly downloaded repo
When I try to build it via build/default.ps1
Then It fails on "dist" path not existing

This fixes that by checking for this path and creating it if it does not exist.