### PR TITLE
Remove max repetition check, fixes #276 keeps nhapi in line with hapi

### DIFF
--- a/src/NHapi.Base/Model/AbstractSegment.cs
+++ b/src/NHapi.Base/Model/AbstractSegment.cs
@@ -167,13 +167,6 @@ namespace NHapi.Base.Model
                     ErrorCode.APPLICATION_INTERNAL_ERROR);
             }
 
-            if (rep > items[number - 1].MaxRepetitions)
-            {
-                throw new HL7Exception(
-                    $"Can't get repetition {rep} from field {number} - maximum repetitions is only {items[number - 1].MaxRepetitions} reps.",
-                    ErrorCode.APPLICATION_INTERNAL_ERROR);
-            }
-
             // add a rep if necessary ...
             if (rep == currentReps)
             {


### PR DESCRIPTION
fixes #276.

Seems that hapi [doesn't do the max repetition check](https://github.com/hapifhir/hapi-hl7v2/blob/554f17b4ef8693cce9ade8ec90dc1dd37f36ca16/hapi-base/src/main/java/ca/uhn/hl7v2/model/AbstractSegment.java#L208), I tested removing this check in nhapi and it prevents the exception also no other tests fail.

Looks like hapi had the max repetition check in the code base but commented out until [this commit](https://github.com/hapifhir/hapi-hl7v2/commit/c22d43ee8baec35a7a328110db9f059c7f5e39bd) on 6 Aug 2012  when they just removed the commented out max repetition check altogether. 