### PR TITLE
Add Support for CharSetUtil and PreParser resolves #312

### DIFF
--- a/src/NHapi.Base/Llp/CharSetUtility.cs
+++ b/src/NHapi.Base/Llp/CharSetUtility.cs
@@ -1,0 +1,150 @@
+﻿/*
+  The contents of this file are subject to the Mozilla Public License Version 1.1
+  (the "License"); you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at http://www.mozilla.org/MPL/
+  Software distributed under the License is distributed on an "AS IS" basis,
+  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+  specific language governing rights and limitations under the License.
+
+  The Original Code is "CharSetUtil.java".
+
+  The Initial Developer of the Original Code is University Health Network. Copyright (C)
+  2001.  All Rights Reserved.
+
+  Contributor(s): Jens Kristian Villadsen from Cetrea A/S; Christian Ohr, Jake Aitchison
+
+  Alternatively, the contents of this file may be used under the terms of the
+  GNU General Public License (the "GPL"), in which case the provisions of the GPL are
+  applicable instead of those above.  If you wish to allow use of your version of this
+  file only under the terms of the GPL and not to allow others to use your version
+  of this file under the MPL, indicate your decision by deleting  the provisions above
+  and replace  them with the notice and other provisions required by the GPL License.
+  If you do not delete the provisions above, a recipient may use your version of
+  this file under either the MPL or the GPL.
+*/
+
+namespace NHapi.Base.Llp
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+
+    using NHapi.Base.Log;
+    using NHapi.Base.Parser;
+    using NHapi.Base.PreParser;
+
+    public class CharSetUtility
+    {
+        private static readonly IHapiLog Log = HapiLogFactory.GetHapiLog(typeof(CharSetUtility));
+
+        public static byte[] WithoutBom(byte[] messageBytes)
+        {
+            var bom = Bom.GetBom(messageBytes);
+            return messageBytes.Skip(bom.BomBytes.Length).ToArray();
+        }
+
+        internal static Encoding CheckCharset(byte[] message, Encoding defaultEncoding = null)
+        {
+            var messageFromBytes = Bom.SkipBom(message);
+
+            return CheckCharset(messageFromBytes, defaultEncoding);
+        }
+
+        internal static Encoding CheckCharset(string message, Encoding defaultEncoding = null)
+        {
+            var encoding = defaultEncoding ?? Encoding.ASCII;
+
+            try
+            {
+                var fields = PreParser.GetFields(message, "MSH-18(0)");
+                var hl7CharsetName = StripNonLowAscii(fields[0]);
+                if (hl7CharsetName.Length > 0)
+                {
+                    encoding = Hl7CharSets.FromHl7Encoding(hl7CharsetName);
+                }
+
+                Log.Trace($"Detected MSH-18 value {hl7CharsetName} so using encoding {encoding.EncodingName}");
+            }
+            catch (EncodingNotSupportedException ex)
+            {
+                Log.Warn($"Invalid or unsupported encoding in MSH-18. Defaulting to {encoding.EncodingName}", ex);
+            }
+            catch (HL7Exception ex)
+            {
+                Log.Warn($"Failed to parse MSH segment. Defaulting to {encoding.EncodingName}", ex);
+            }
+
+            return encoding;
+        }
+
+        private static string StripNonLowAscii(string theString)
+        {
+            if (theString == null)
+            {
+                return string.Empty;
+            }
+
+            var builder = new StringBuilder();
+
+            foreach (var next in theString)
+            {
+                if (next > 0 && next < 127)
+                {
+                    builder.Append(next);
+                }
+            }
+
+            return builder.ToString();
+        }
+
+        private class Bom
+        {
+            private static readonly IList<Bom> KnownBoms = new List<Bom>
+            {
+                new Bom(new byte[] { }, Encoding.ASCII),
+                new Bom(new byte[] { 0xEF, 0xBB, 0xBF }, Encoding.UTF8),
+                new Bom(new byte[] { 0xFF, 0xFE }, Encoding.Unicode),                           // UTF-16LE
+                new Bom(new byte[] { 0xFE, 0xFF, 0xBF }, Encoding.BigEndianUnicode),            // UTF-16BE
+                new Bom(new byte[] { 0xFF, 0xFE, 0x00, 0x00 }, Encoding.UTF32),                 // UTF-32LE
+                new Bom(new byte[] { 0x00, 0x00, 0xFE, 0xFF }, new UTF32Encoding(true, true)),  // UTF-32BE
+            };
+
+            public Bom(byte[] bomBytes, Encoding encoding)
+            {
+                BomBytes = bomBytes;
+                Encoding = encoding;
+            }
+
+            public byte[] BomBytes { get; }
+
+            public Encoding Encoding { get; }
+
+            public static string SkipBom(byte[] messageBytes)
+            {
+                var bom = GetBom(messageBytes);
+                var encoding = bom.Encoding;
+                var messageBytesWithoutBom = messageBytes.Skip(bom.BomBytes.Length).ToArray();
+                return encoding.GetString(messageBytesWithoutBom);
+            }
+
+            public static Bom GetBom(byte[] messageBytes)
+            {
+                if (messageBytes == null)
+                {
+                    return KnownBoms[0];
+                }
+
+                foreach (var bom in KnownBoms)
+                {
+                    var messageBomBytes = messageBytes.Take(bom.BomBytes.Length);
+                    if (bom.BomBytes.SequenceEqual(messageBomBytes))
+                    {
+                        return bom;
+                    }
+                }
+
+                return KnownBoms[0];
+            }
+        }
+    }
+}

--- a/src/NHapi.Base/Llp/CharSetUtility.cs
+++ b/src/NHapi.Base/Llp/CharSetUtility.cs
@@ -101,12 +101,12 @@ namespace NHapi.Base.Llp
         {
             private static readonly IList<Bom> KnownBoms = new List<Bom>
             {
-                new Bom(new byte[] { }, Encoding.ASCII),
                 new Bom(new byte[] { 0xEF, 0xBB, 0xBF }, Encoding.UTF8),
                 new Bom(new byte[] { 0xFF, 0xFE }, Encoding.Unicode),                           // UTF-16LE
                 new Bom(new byte[] { 0xFE, 0xFF, 0xBF }, Encoding.BigEndianUnicode),            // UTF-16BE
                 new Bom(new byte[] { 0xFF, 0xFE, 0x00, 0x00 }, Encoding.UTF32),                 // UTF-32LE
                 new Bom(new byte[] { 0x00, 0x00, 0xFE, 0xFF }, new UTF32Encoding(true, true)),  // UTF-32BE
+                new Bom(new byte[] { }, Encoding.ASCII),
             };
 
             public Bom(byte[] bomBytes, Encoding encoding)

--- a/src/NHapi.Base/Llp/Hl7CharSets.cs
+++ b/src/NHapi.Base/Llp/Hl7CharSets.cs
@@ -35,7 +35,7 @@ namespace NHapi.Base.Llp
     /// <summary>
     /// HL7 Charsets from Table 0211 mapped to dotnet <see cref="Encoding"/>.
     /// </summary>
-    internal class Hl7CharSets
+    internal static class Hl7CharSets
     {
         private static readonly Dictionary<string, string> EncodingMap = new ()
         {

--- a/src/NHapi.Base/Llp/Hl7CharSets.cs
+++ b/src/NHapi.Base/Llp/Hl7CharSets.cs
@@ -1,0 +1,98 @@
+﻿/*
+  The contents of this file are subject to the Mozilla Public License Version 1.1
+  (the "License"); you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at http://www.mozilla.org/MPL/
+  Software distributed under the License is distributed on an "AS IS" basis,
+  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+  specific language governing rights and limitations under the License.
+
+  The Original Code is "HL7Charsets.java".  Description:
+  "Content of HL7 table 0211 mapped to dotnet Encoding"
+
+  The Initial Developer of the Original Code is University Health Network. Copyright (C)
+  2001.  All Rights Reserved.
+
+  Contributor(s): Christian Ohr, Jake Aitchison
+
+  Alternatively, the contents of this file may be used under the terms of the
+  GNU General Public License (the "GPL"), in which case the provisions of the GPL are
+  applicable instead of those above.  If you wish to allow use of your version of this
+  file only under the terms of the GPL and not to allow others to use your version
+  of this file under the MPL, indicate your decision by deleting  the provisions above
+  and replace  them with the notice and other provisions required by the GPL License.
+  If you do not delete the provisions above, a recipient may use your version of
+  this file under either the MPL or the GPL.
+*/
+
+namespace NHapi.Base.Llp
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    using NHapi.Base.Parser;
+
+    /// <summary>
+    /// HL7 Charsets from Table 0211 mapped to dotnet <see cref="Encoding"/>.
+    /// </summary>
+    internal class Hl7CharSets
+    {
+        private static readonly Dictionary<string, string> EncodingMap = new ()
+        {
+            { "ASCII", Encoding.ASCII.BodyName },           // ASCII
+            { "8859/1", "iso-8859-1" },                     // Western European (ISO)
+            { "8859/2", "iso-8859-2" },                     // Central European (ISO)
+            { "8859/3", "iso-8859-3" },                     // Latin 3 (ISO)
+            { "8859/4", "iso-8859-4" },                     // Baltic (ISO)
+            { "8859/5", "iso-8859-5" },                     // Cyrillic (ISO)
+            { "8859/6", "iso-8859-6" },                     // Arabic (ISO)
+            { "8859/7", "iso-8859-7" },                     // Greek (ISO)
+            { "8859/8", "iso-8859-8" },                     // Hebrew (ISO-Visual)
+            { "8859/9", "iso-8859-9" },                     // Turkish (ISO)
+            { "8859/15", "iso-8859-15" },                   // Latin 9 (ISO)
+            { "ISO IR6", "ISO IR6" },
+            { "ISO IR14", "ISO IR14" },
+            { "ISO IR87", "ISO IR87" },
+            { "ISO IR159", "ISO IR159" },
+            { "GB 18030-2000", "gb18030" },                 // Chinese Simplified (GB18030)
+            { "KS X 1001", "euc-kr" },                      // Korean (EUC)
+            { "CNS 11643-1992", "CNS 11643-1992" },
+            { "BIG-5", "big5" },                            // Chinese Traditional (Big5)
+            { "UNICODE", Encoding.UTF8.BodyName },
+            { "UNICODE UTF-8", Encoding.UTF8.BodyName },    // Unicode (UTF-8)
+            { "UNICODE UTF-16", "utf-16" },                 // Unicode
+            { "UNICODE UTF-32", Encoding.UTF32.BodyName },  // Unicode (UTF-32)
+        };
+
+        /// <summary>
+        /// Returns the dotnet <see cref="Encoding"/> for the HL7 charset name.
+        /// <a href="https://learn.microsoft.com/en-us/dotnet/api/system.text.encoding#list-of-encodings">list of supported encodings</a>.
+        /// </summary>
+        /// <param name="hl7EncodingName"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException">When null empty or white-space <paramref name="hl7EncodingName"/>.</exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="hl7EncodingName" /> is not a valid code page name.
+        /// -or-
+        /// The code page indicated by <paramref name="hl7EncodingName" /> is not supported by the underlying platform.</exception>
+        /// <exception cref="EncodingNotSupportedException"><paramref name="hl7EncodingName"/> is unknown.</exception>
+        public static Encoding FromHl7Encoding(string hl7EncodingName)
+        {
+#if NET35
+            if (string.IsNullOrEmpty(hl7EncodingName) || hl7EncodingName.Trim().Length == 0)
+#else
+            if (string.IsNullOrWhiteSpace(hl7EncodingName))
+#endif
+            {
+                throw new ArgumentException("Should not be null empty or white-space.", nameof(hl7EncodingName));
+            }
+
+            if (!EncodingMap.TryGetValue(hl7EncodingName, out var mappedEncoding))
+            {
+                throw new EncodingNotSupportedException(hl7EncodingName);
+            }
+
+            return Encoding.GetEncoding(mappedEncoding);
+        }
+    }
+}

--- a/src/NHapi.Base/Llp/Hl7CharSets.cs
+++ b/src/NHapi.Base/Llp/Hl7CharSets.cs
@@ -39,29 +39,29 @@ namespace NHapi.Base.Llp
     {
         private static readonly Dictionary<string, string> EncodingMap = new ()
         {
-            { "ASCII", Encoding.ASCII.BodyName },           // ASCII
-            { "8859/1", "iso-8859-1" },                     // Western European (ISO)
-            { "8859/2", "iso-8859-2" },                     // Central European (ISO)
-            { "8859/3", "iso-8859-3" },                     // Latin 3 (ISO)
-            { "8859/4", "iso-8859-4" },                     // Baltic (ISO)
-            { "8859/5", "iso-8859-5" },                     // Cyrillic (ISO)
-            { "8859/6", "iso-8859-6" },                     // Arabic (ISO)
-            { "8859/7", "iso-8859-7" },                     // Greek (ISO)
-            { "8859/8", "iso-8859-8" },                     // Hebrew (ISO-Visual)
-            { "8859/9", "iso-8859-9" },                     // Turkish (ISO)
-            { "8859/15", "iso-8859-15" },                   // Latin 9 (ISO)
+            { "ASCII", Encoding.ASCII.BodyName },               // ASCII (us-ascii)
+            { "8859/1", "iso-8859-1" },                         // Western European (ISO)
+            { "8859/2", "iso-8859-2" },                         // Central European (ISO)
+            { "8859/3", "iso-8859-3" },                         // Latin 3 (ISO)
+            { "8859/4", "iso-8859-4" },                         // Baltic (ISO)
+            { "8859/5", "iso-8859-5" },                         // Cyrillic (ISO)
+            { "8859/6", "iso-8859-6" },                         // Arabic (ISO)
+            { "8859/7", "iso-8859-7" },                         // Greek (ISO)
+            { "8859/8", "iso-8859-8" },                         // Hebrew (ISO-Visual)
+            { "8859/9", "iso-8859-9" },                         // Turkish (ISO)
+            { "8859/15", "iso-8859-15" },                       // Latin 9 (ISO)
             { "ISO IR6", "ISO IR6" },
             { "ISO IR14", "ISO IR14" },
             { "ISO IR87", "ISO IR87" },
             { "ISO IR159", "ISO IR159" },
-            { "GB 18030-2000", "gb18030" },                 // Chinese Simplified (GB18030)
-            { "KS X 1001", "euc-kr" },                      // Korean (EUC)
+            { "GB 18030-2000", "gb18030" },                     // Chinese Simplified (GB18030)
+            { "KS X 1001", "euc-kr" },                          // Korean (EUC)
             { "CNS 11643-1992", "CNS 11643-1992" },
-            { "BIG-5", "big5" },                            // Chinese Traditional (Big5)
-            { "UNICODE", Encoding.UTF8.BodyName },
-            { "UNICODE UTF-8", Encoding.UTF8.BodyName },    // Unicode (UTF-8)
-            { "UNICODE UTF-16", "utf-16" },                 // Unicode
-            { "UNICODE UTF-32", Encoding.UTF32.BodyName },  // Unicode (UTF-32)
+            { "BIG-5", "big5" },                                // Chinese Traditional (Big5)
+            { "UNICODE", Encoding.UTF8.BodyName },              // Unicode (UTF-8)
+            { "UNICODE UTF-8", Encoding.UTF8.BodyName },        // Unicode (UTF-8)
+            { "UNICODE UTF-16", Encoding.Unicode.BodyName },    // Unicode (UTF-16LE)
+            { "UNICODE UTF-32", Encoding.UTF32.BodyName },      // Unicode (UTF-32LE)
         };
 
         /// <summary>

--- a/src/NHapi.Base/PreParser/DatumPath.cs
+++ b/src/NHapi.Base/PreParser/DatumPath.cs
@@ -1,0 +1,455 @@
+﻿/*
+  The contents of this file are subject to the Mozilla Public License Version 1.1
+  (the "License"); you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at http://www.mozilla.org/MPL/
+  Software distributed under the License is distributed on an "AS IS" basis,
+  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+  specific language governing rights and limitations under the License.
+
+  The Original Code is "DatumPath.java".
+
+  The Initial Developer of the Original Code is University Health Network. Copyright (C)
+  2001.  All Rights Reserved.
+
+  Contributor(s): James Agnew, Jake Aitchison
+
+  Alternatively, the contents of this file may be used under the terms of the
+  GNU General Public License (the "GPL"), in which case the provisions of the GPL are
+  applicable instead of those above.  If you wish to allow use of your version of this
+  file only under the terms of the GPL and not to allow others to use your version
+  of this file under the MPL, indicate your decision by deleting  the provisions above
+  and replace  them with the notice and other provisions required by the GPL License.
+  If you do not delete the provisions above, a recipient may use your version of
+  this file under either the MPL or the GPL.
+*/
+namespace NHapi.Base.PreParser
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+
+    /// <summary>
+    /// <para>
+    /// An object of this class represents a variable-size path for identifying
+    /// the location of a datum within an HL7 message, which we can use for
+    /// maintaining parser state and for generating a suitable string key (in the
+    /// <c>ZYX[a]-b[c]-d-e</c> style) for a piece of data in the message (see <see cref="ToString" />).
+    /// </para>
+    /// <para>
+    /// The elements are:
+    /// segmentID / segmentRepIdx / fieldIdx / fieldRepIdx / compIdx / subcompIdx
+    /// ("rep" means "repetition").
+    /// </para>
+    /// <para>
+    /// segmentID is a <see cref="string"/>, the rest are <see cref="int"/>.
+    /// </para>
+    /// <para>
+    /// It is variable-size path-style in that if it has a size of 1, the one element
+    /// will be the segmentID; if it has a size of two, element 0 will be the segmentID
+    /// and element 1 will be the segmentRepIdx, etc.  This class can't represent a
+    /// fieldIdx without having segmentID / segmentRepIdx, etc. etc.
+    /// </para>
+    /// <para>
+    /// Possible sizes: 0 to 6 inclusive.
+    /// </para>
+    /// <para>
+    /// As <see cref="ToString" /> simply converts this' integer values to strings <c>(1 => "1")</c>, and
+    /// since for some reason the <c>ZYX[a]-b[c]-d-e</c> style counts b, d, e starting from 1
+    /// and a, c from 0 -- it is intended that one store the numeric values in this
+    /// class starting from 1 for fieldIdx (element 2), compIdx (4) and subcompIdx
+    /// (5), and from 0 for segmentRepIdx (1) and fieldRepIdx (3).
+    /// </para>
+    /// <para>
+    /// Default values provided by <see cref="ReSize" /> and by <see cref="ToString" /> do this.
+    /// </para>
+    /// </summary>
+    public class DatumPath : ICloneable
+    {
+        private const int MAXSIZE = 6;
+
+        private readonly List<object> path;
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="DatumPath"/> class.
+        /// </summary>
+        public DatumPath()
+        {
+            this.path = new List<object>(MAXSIZE);
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="DatumPath"/> class from the values of another instance.
+        /// </summary>
+        /// <param name="other"></param>
+        public DatumPath(DatumPath other)
+            : this()
+        {
+            this.Copy(other);
+        }
+
+        /// <summary>
+        /// Gets the number of elements in the path.
+        /// </summary>
+        public int Size => this.path.Count;
+
+        public static bool operator ==(DatumPath left, DatumPath right)
+        {
+            if (left is null && right is null)
+            {
+                return true;
+            }
+
+            return left?.Equals(right) ?? false;
+        }
+
+        public static bool operator !=(DatumPath left, DatumPath right)
+        {
+            return !(left == right);
+        }
+
+        /// <summary>
+        /// <para>
+        /// Grows <see cref="DatumPath"/> by 1, inserting <paramref name="newValue"/> at the end.
+        /// </para>
+        /// <para>
+        /// <paramref name="newValue" /> must be a <see cref="string"/> or an <see cref="int"/>
+        /// depending on the index where it will be inserted, as noted at <see cref="Set(int, int?)"/>.
+        /// </para>
+        /// <para>
+        /// If being inserted at index 0 then the type of <paramref name="newValue"/> must be a <see cref="string"/>
+        /// otherwise it must be an <see cref="int" />.
+        /// </para>
+        /// <example>
+        /// This method can be chained:
+        /// <code>
+        /// path.Add("ZYX").Add(1).Add(2);
+        /// </code>
+        /// </example>
+        /// </summary>
+        /// <param name="newValue"></param>
+        /// <exception cref="ArgumentOutOfRangeException">If <see cref="Size"/> is already equal to 6.</exception>
+        /// <exception cref="InvalidOperationException">If <see cref="Size"/> is less then 1.</exception>
+        /// <returns>this.</returns>
+        public DatumPath Add(int newValue)
+        {
+            if (this.Size < 1)
+            {
+                throw new InvalidOperationException("Cannot add value type of int to a DatumPath with no elements.");
+            }
+
+            if (this.Size == MAXSIZE)
+            {
+                throw new ArgumentOutOfRangeException(nameof(Size), "Cannot add value to a DatumPath with 6 elements.");
+            }
+
+            this.path.Add(newValue);
+
+            return this;
+        }
+
+        /// <summary>
+        /// <para>
+        /// Grows <see cref="DatumPath"/> by 1, inserting <paramref name="newValue"/> at the end.
+        /// </para>
+        /// <para>
+        /// <paramref name="newValue" /> must be a <see cref="string"/> or an <see cref="int"/>
+        /// depending on the index where it will be inserted, as noted at <see cref="Set(int, string)"/>.
+        /// </para>
+        /// <para>
+        /// If being inserted at index 0 then the type of <paramref name="newValue"/> must be a <see cref="string"/>
+        /// otherwise it must be an <see cref="int" />.
+        /// </para>
+        /// <example>
+        /// This method can be chained:
+        /// <code>
+        /// path.Add("ZYX").Add(1).Add(2);
+        /// </code>
+        /// </example>
+        /// </summary>
+        /// <param name="newValue"></param>
+        /// <returns>this.</returns>
+        /// <exception cref="InvalidOperationException">If <see cref="Size"/> is not equal to 0.</exception>
+        public DatumPath Add(string newValue)
+        {
+            if (this.Size != 0)
+            {
+                throw new InvalidOperationException("Cannot add value type of string to a DatumPath which already contains elements.");
+            }
+
+            this.path.Add(newValue);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Gets an element of the path at the specified index.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The type of the value returned is determined by the index.
+        /// </para>
+        /// <para>
+        /// If the index equal to 0 then the value returned is a <see cref="string"/>.
+        /// </para>
+        /// <para>
+        /// If the index is greater than 1 then the value returned is a <see cref="int"/>.
+        /// </para>
+        /// </remarks>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        /// <exception cref="IndexOutOfRangeException">
+        /// If the index specified is less than 0 or greater than <see cref="Size"/>.
+        /// </exception>
+        public object Get(int index)
+        {
+            return this.path[index];
+        }
+
+        /// <summary>
+        /// Sets an element of the path, at the specified index.
+        /// </summary>
+        /// <param name="index">Location to add element.</param>
+        /// <param name="newValue">Value to add.</param>
+        /// <exception cref="ArgumentException">When attempting to set an int value to index position 0.</exception>
+        /// <exception cref="ArgumentNullException">If <paramref name="newValue"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// If <paramref name="index" /> is less than 0 or greater than or equal to <see cref="Size"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">if <paramref name="index" /> is greater than 6.</exception>
+        public void Set(int index, int? newValue)
+        {
+            if (index > MAXSIZE)
+            {
+                throw new ArgumentOutOfRangeException(nameof(Size), "Cannot add value to a DatumPath with 6 elements.");
+            }
+
+            if ((index < 0) || (index >= this.path.Count))
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+
+            if (index == 0)
+            {
+                throw new ArgumentException("When setting the value at index 0 the value must be of type string", nameof(index));
+            }
+
+            this.path[index] = newValue ?? throw new ArgumentNullException(nameof(newValue));
+        }
+
+        /// <summary>
+        /// Sets an element of the path, at the specified index.
+        /// </summary>
+        /// <param name="index">Location to add element.</param>
+        /// <param name="newValue">Value to add.</param>
+        /// <exception cref="ArgumentException">When attempting to set a string value to index position other than 0.</exception>
+        /// <exception cref="ArgumentNullException">If <paramref name="newValue"/> is null.</exception>
+        public void Set(int index, string newValue)
+        {
+            if (index != 0)
+            {
+                throw new ArgumentException("When setting a value of type string you can only supply an index of 0", nameof(index));
+            }
+
+            this.path[index] = newValue ?? throw new ArgumentNullException(nameof(newValue));
+        }
+
+        /// <summary>
+        /// <para>
+        /// Resize the <see cref="DatumPath"/>.
+        /// </para>
+        /// <para>
+        /// If <paramref name="newSize"/> is greater than the current
+        /// size, then the new elements are set to default values.
+        /// </para>
+        /// <para>
+        /// Then we put default values into the new elements: i.e. <see cref="string.Empty"/>
+        /// into the string element, 1 into the elements 2, 4, and 5, and 0 into elements 1 and 3.
+        /// </para>
+        /// <para>
+        /// If <paramref name="newSize"/> is less than the current size, then the last elements are removed.
+        /// </para>
+        /// </summary>
+        /// <param name="newSize">The desired size for the path.</param>
+        /// <exception cref="ArgumentOutOfRangeException">If <paramref name="newSize" /> is greater than 6.</exception>
+        /// <returns>this.</returns>
+        public DatumPath ReSize(int newSize)
+        {
+            if (newSize > MAXSIZE)
+            {
+                throw new ArgumentOutOfRangeException(nameof(Size), "DatumPath cannot contain more than 6 elements.");
+            }
+
+            var oldSize = this.path.Count;
+
+            while (this.path.Count < newSize)
+            {
+                this.path.Add(null);
+            }
+
+            while (this.path.Count > newSize)
+            {
+                this.path.RemoveAt(this.path.Count - 1);
+            }
+
+            if (newSize <= oldSize)
+            {
+                return this;
+            }
+
+            // give the new elements some default values:
+            for (var i = oldSize; i < newSize; ++i)
+            {
+                if (i == 0)
+                {
+                    this.Set(i, string.Empty);
+                }
+                else
+                {
+                    this.Set(i, (i == 1 || i == 3) ? 0 : 1);
+                }
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Resets the <see cref="DatumPath"/> to the default state.
+        /// </summary>
+        /// <returns></returns>
+        public DatumPath Clear()
+        {
+            this.ReSize(0);
+            return this;
+        }
+
+        /// <summary>
+        /// Clones the <see cref="DatumPath"/>.
+        /// </summary>
+        /// <returns></returns>
+        public object Clone()
+        {
+            return new DatumPath(this);
+        }
+
+        /// <summary>
+        /// Copy the path elements from the specified <see cref="DatumPath"/>.
+        /// </summary>
+        /// <param name="other">The instance of <see cref="DatumPath"/> to copy path elements from.</param>
+        /// <exception cref="InvalidOperationException">
+        /// If the values of the <paramref name="other" /> are not of the expected types (either <see cref="string"/> or <see cref="int"/>).
+        /// </exception>
+        public void Copy(DatumPath other)
+        {
+            this.ReSize(0);
+            for (var i = 0; i < other.Size; ++i)
+            {
+                var pathElement = other.Get(i);
+                switch (pathElement)
+                {
+                    case int intValue:
+                        this.Add(intValue);
+                        break;
+                    case string stringValue:
+                        this.Add(stringValue);
+                        break;
+                    default:
+                        throw new InvalidOperationException($"Unexpected type in DatumPath.Copy: {pathElement?.GetType()}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns a string that represents the current <see cref="DatumPath"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Outputs the path (from segmentID onward) in the <c>ZYX[a]-b[c]-d-e</c>
+        /// style (TODO: give it a name), suitable for a key in a map of message datum paths to values.
+        /// </para>
+        /// <para>
+        /// Integer values are converted to strings directly <c>(1 => "1")</c> so when you
+        /// constructed this you should have started counting from 1 for everything but
+        /// the "repeat" fields, if you truly want the <c>ZYX[a]-b[c]-d-e</c> style.
+        /// </para>
+        /// <para>
+        /// If <see cref="ToString"/> is called when this has a size in [1, 6) (=> missing numeric
+        /// elements), then we act as though the elements in [size(), 6) are 0 or 1 as
+        /// appropriate for each element.  We don't provide a default for the element 0
+        /// (the String element): will throw an <see cref="ArgumentOutOfRangeException" /> if <c>(size() == 1)</c>.
+        /// </para>
+        /// <example>
+        /// <code>
+        /// new DatumPath().Add("ZYX").Add(2).Add(6).ToString();
+        /// </code>
+        /// Would yield "ZYX[2]-6[0]-1-1"
+        /// </example>
+        /// </remarks>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// If <see cref="Size"/> is less than or equal to 1.
+        /// </exception>
+        public override string ToString()
+        {
+            var builder = new StringBuilder();
+
+            if (this.path.Count >= 1)
+            {
+                var extendedCopy = (DatumPath)this.Clone();
+                extendedCopy.ReSize(MAXSIZE);
+
+                for (var i = 0; i < extendedCopy.Size; ++i)
+                {
+                    switch (i)
+                    {
+                        case 0:
+                            builder.Append(extendedCopy.Get(i));
+                            break;
+                        case 1:
+                        case 3:
+                            builder.Append("[").Append(extendedCopy.Get(i)).Append("]");
+                            break;
+                        case 2:
+                        case 4:
+                        case 5:
+                            builder.Append("-").Append(extendedCopy.Get(i));
+                            break;
+                    }
+                }
+            }
+            else
+            {
+                throw new ArgumentOutOfRangeException(nameof(this.path.Count));
+            }
+
+            return builder.ToString();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is null)
+            {
+                return false;
+            }
+
+            if (obj.GetType() != typeof(DatumPath))
+            {
+                return false;
+            }
+
+            var other = (DatumPath)obj;
+
+            return this.path.SequenceEqual(other.path);
+        }
+
+        public override int GetHashCode()
+        {
+            return path != null ? path.GetHashCode() : 0;
+        }
+
+        protected bool Equals(DatumPath other)
+        {
+            return Equals((object)other);
+        }
+    }
+}

--- a/src/NHapi.Base/PreParser/DatumPath.cs
+++ b/src/NHapi.Base/PreParser/DatumPath.cs
@@ -64,7 +64,7 @@ namespace NHapi.Base.PreParser
     /// Default values provided by <see cref="ReSize" /> and by <see cref="ToString" /> do this.
     /// </para>
     /// </summary>
-    public class DatumPath : ICloneable
+    public class DatumPath : IEquatable<DatumPath>, ICloneable
     {
         private const int MAXSIZE = 6;
 
@@ -375,8 +375,7 @@ namespace NHapi.Base.PreParser
         /// <para>
         /// If <see cref="ToString"/> is called when this has a size in [1, 6) (=> missing numeric
         /// elements), then we act as though the elements in [size(), 6) are 0 or 1 as
-        /// appropriate for each element.  We don't provide a default for the element 0
-        /// (the String element): will throw an <see cref="ArgumentOutOfRangeException" /> if <c>(size() == 1)</c>.
+        /// appropriate for each element.  We don't provide a default for the element 0.
         /// </para>
         /// <example>
         /// <code>
@@ -386,40 +385,32 @@ namespace NHapi.Base.PreParser
         /// </example>
         /// </remarks>
         /// <returns></returns>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// If <see cref="Size"/> is less than or equal to 1.
-        /// </exception>
         public override string ToString()
         {
+            if (this.path.Count < 1)
+            {
+                return "???[?]-?[?]-?-?";
+            }
+
             var builder = new StringBuilder();
 
-            if (this.path.Count >= 1)
-            {
-                var extendedCopy = (DatumPath)this.Clone();
-                extendedCopy.ReSize(MAXSIZE);
+            var extendedCopy = (DatumPath)this.Clone();
+            extendedCopy.ReSize(MAXSIZE);
 
-                for (var i = 0; i < extendedCopy.Size; ++i)
-                {
-                    switch (i)
-                    {
-                        case 0:
-                            builder.Append(extendedCopy.Get(i));
-                            break;
-                        case 1:
-                        case 3:
-                            builder.Append("[").Append(extendedCopy.Get(i)).Append("]");
-                            break;
-                        case 2:
-                        case 4:
-                        case 5:
-                            builder.Append("-").Append(extendedCopy.Get(i));
-                            break;
-                    }
-                }
-            }
-            else
+            for (var i = 0; i < extendedCopy.Size; ++i)
             {
-                throw new ArgumentOutOfRangeException(nameof(this.path.Count));
+                if (i == 0)
+                {
+                    builder.Append(extendedCopy.Get(i));
+                }
+                else if (i is 1 or 3)
+                {
+                    builder.Append("[").Append(extendedCopy.Get(i)).Append("]");
+                }
+                else if (i is 2 or 4 or 5)
+                {
+                    builder.Append("-").Append(extendedCopy.Get(i));
+                }
             }
 
             return builder.ToString();
@@ -447,7 +438,7 @@ namespace NHapi.Base.PreParser
             return path != null ? path.GetHashCode() : 0;
         }
 
-        protected bool Equals(DatumPath other)
+        public bool Equals(DatumPath other)
         {
             return Equals((object)other);
         }

--- a/src/NHapi.Base/PreParser/DatumPathExtensions.cs
+++ b/src/NHapi.Base/PreParser/DatumPathExtensions.cs
@@ -1,0 +1,220 @@
+﻿/*
+  The contents of this file are subject to the Mozilla Public License Version 1.1
+  (the "License"); you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at http://www.mozilla.org/MPL/
+  Software distributed under the License is distributed on an "AS IS" basis,
+  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+  specific language governing rights and limitations under the License.
+
+  Some of the original code can be found in "DatumPath.java".
+
+  The Initial Developer of the Original Code is University Health Network. Copyright (C)
+  2001.  All Rights Reserved.
+
+  Contributor(s): James Agnew, Christian Ohr, Jake Aitchison
+
+  Alternatively, the contents of this file may be used under the terms of the
+  GNU General Public License (the "GPL"), in which case the provisions of the GPL are
+  applicable instead of those above.  If you wish to allow use of your version of this
+  file only under the terms of the GPL and not to allow others to use your version
+  of this file under the MPL, indicate your decision by deleting  the provisions above
+  and replace  them with the notice and other provisions required by the GPL License.
+  If you do not delete the provisions above, a recipient may use your version of
+  this file under either the MPL or the GPL.
+*/
+namespace NHapi.Base.PreParser
+{
+    using System;
+    using System.Text.RegularExpressions;
+
+    using NHapi.Base.Util;
+
+    public static class DatumPathExtensions
+    {
+        private const int MAXSIZE = 6;
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "StyleCop.CSharp.NamingRules",
+            "SA1310:Field names should not contain underscore",
+            Justification = "Because these are constants and not just fields there is a rule clash.")]
+        private const string PATH_SPEC_PATTERN =
+            @"^(?<segment>[A-Z]{3})(\((?<segmentRepetition>\d+)\))?-((?<fieldNumber>(?:[1-9]|\d\d\d*))(\((?<fieldRepetition>\d+)\))?)(-(?<component>(?:[1-9]|\d\d\d*)))?(-(?<subComponent>(?:[1-9]|\d\d\d*)))?$";
+
+        /// <summary>
+        /// <para>
+        /// Compares the numeric parts of <paramref name="input"/> and <paramref name="other"/>. "string style", start from
+        /// the left: if this[1] &lt; other[1], then return true, if this[1] &gt; other[1] then
+        /// return false, else repeat with [2] ... if we compare all elements, then return
+        /// false (they're the same.)
+        /// </para>
+        /// <para>
+        /// What are actually compared are copies of this and other that have been grown
+        /// to a capacity of 6 (default values in effect), so they'll have the same size.
+        /// </para>
+        /// <para>
+        /// This is just a little thing that gets used in the class XML. Look there for
+        /// a justification of it's existence.
+        /// </para>
+        /// e.g.
+        /// <example>
+        /// <code>
+        /// [1, 1, 1, 1] &lt; [1, 1, 1, 2]
+        /// [1, 2, 1, 1] &lt; [1, 2, 1, 2]
+        /// [1, 1, 5, 5] &lt; [1, 2]
+        /// [1, 1] &lt; [1, 1, 5, 5]
+        /// </code>
+        /// </example>
+        /// </summary>
+        /// <param name="input">Current instance of <see cref="DatumPath"/>.</param>
+        /// <param name="other">Instance of <see cref="DatumPath"/> to compare to.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="input"/> is null.</exception>
+        /// <returns></returns>
+        public static bool NumbersLessThan(this DatumPath input, DatumPath other)
+        {
+            if (input is null)
+            {
+                throw new ArgumentNullException(nameof(input));
+            }
+
+            if (other is null)
+            {
+                return false;
+            }
+
+            var extendedCopyThis = new DatumPath(input);
+            extendedCopyThis.ReSize(MAXSIZE);
+
+            var extendedCopyOther = new DatumPath(other);
+            extendedCopyOther.ReSize(MAXSIZE);
+
+            var lessThan = false;
+            for (var i = 1; !lessThan && (i < MAXSIZE); ++i)
+            {
+                var thisPathElement = (int)extendedCopyThis.Get(i);
+                var otherPathElement = (int)extendedCopyOther.Get(i);
+                if (thisPathElement > otherPathElement)
+                {
+                    break;
+                }
+
+                lessThan = thisPathElement < otherPathElement;
+            }
+
+            return lessThan;
+        }
+
+        /// <summary>
+        /// Determines whether this <see cref="DatumPath"/> instance starts with the same
+        /// path elements as the specified <see cref="DatumPath"/>.
+        /// <example>
+        /// <code>
+        /// var result = path.StartsWith(otherPath);
+        /// </code>
+        /// </example>
+        /// </summary>
+        /// <param name="input">The <see cref="DatumPath"/> instance.</param>
+        /// <param name="prefix">The <see cref="DatumPath"/> to compare.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="input"/> is null.</exception>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="input"/> starts with the same
+        /// path elements as <paramref name="prefix"/>; otherwise, <see langword="false" />.
+        /// </returns>
+        public static bool StartsWith(this DatumPath input, DatumPath prefix)
+        {
+            if (input is null)
+            {
+                throw new ArgumentNullException(nameof(input));
+            }
+
+            if (prefix is null)
+            {
+                return false;
+            }
+
+            if (input.Size < prefix.Size)
+            {
+                return false;
+            }
+
+            var result = true;
+            for (var i = 0; i < prefix.Size; ++i)
+            {
+                if (i == 0)
+                {
+                    result &= (string)input.Get(i) == (string)prefix.Get(i);
+                    continue;
+                }
+
+                result &= (int?)input.Get(i) == (int?)prefix.Get(i);
+            }
+
+            return result;
+        }
+
+        public static DatumPath FromPathSpec(this string pathSpec)
+        {
+            if (pathSpec is null)
+            {
+                throw new ArgumentNullException(nameof(pathSpec));
+            }
+
+            var match = Regex.Match(pathSpec, PATH_SPEC_PATTERN);
+
+            if (!match.Success)
+            {
+                throw new ArgumentException($"Invalid path specification: {pathSpec}", nameof(pathSpec));
+            }
+
+            var segment = match.Groups["segment"].Value;
+            int.TryParse(match.Groups["segmentRepetition"].Value, out var segmentRepetition);
+            int.TryParse(match.Groups["fieldNumber"].Value, out var fieldNumber);
+            int.TryParse(match.Groups["fieldRepetition"].Value, out var fieldRepetition);
+            int component = int.TryParse(match.Groups["component"].Value, out component) ? component : 1;
+            int subComponent = int.TryParse(match.Groups["subComponent"].Value, out subComponent) ? subComponent : 1;
+
+            var result = new DatumPath();
+            result.Add(segment)
+                .Add(segmentRepetition)
+                .Add(fieldNumber)
+                .Add(fieldRepetition)
+                .Add(component)
+                .Add(subComponent);
+
+            return result;
+        }
+
+        public static DatumPath FromPathSpecOriginal(this string pathSpec)
+        {
+            var tokens = new SupportClass.Tokenizer(pathSpec, "-", false);
+            var segmentSpec = tokens.NextToken();
+            tokens = new SupportClass.Tokenizer(segmentSpec, "()", false);
+            var segmentName = tokens.NextToken();
+
+            var segmentRepetition = 0;
+            if (tokens.HasMoreTokens())
+            {
+                var repetition = tokens.NextToken();
+                try
+                {
+                    segmentRepetition = int.Parse(repetition);
+                }
+                catch (Exception e)
+                {
+                    throw new ArgumentException($"Invalid path specification: {pathSpec}", nameof(pathSpec), e);
+                }
+            }
+
+            var indices = Terser.GetIndices(pathSpec);
+
+            var result = new DatumPath();
+            result.Add(segmentName)
+                .Add(segmentRepetition)
+                .Add(indices[0])
+                .Add(indices[1])
+                .Add(indices[2])
+                .Add(indices[3]);
+
+            return result;
+        }
+    }
+}

--- a/src/NHapi.Base/PreParser/Er7.cs
+++ b/src/NHapi.Base/PreParser/Er7.cs
@@ -1,0 +1,273 @@
+﻿/*
+  The contents of this file are subject to the Mozilla Public License Version 1.1
+  (the "License"); you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at http://www.mozilla.org/MPL/
+  Software distributed under the License is distributed on an "AS IS" basis,
+  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+  specific language governing rights and limitations under the License.
+
+  The Original Code is "ER7.java".
+
+  The Initial Developer of the Original Code is University Health Network. Copyright (C)
+  2001.  All Rights Reserved.
+
+  Contributor(s): James Agnew, Christian Ohr, Jake Aitchison
+
+  Alternatively, the contents of this file may be used under the terms of the
+  GNU General Public License (the "GPL"), in which case the provisions of the GPL are
+  applicable instead of those above.  If you wish to allow use of your version of this
+  file only under the terms of the GPL and not to allow others to use your version
+  of this file under the MPL, indicate your decision by deleting  the provisions above
+  and replace  them with the notice and other provisions required by the GPL License.
+  If you do not delete the provisions above, a recipient may use your version of
+  this file under either the MPL or the GPL.
+*/
+namespace NHapi.Base.PreParser
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using NHapi.Base.Parser;
+
+    public static class Er7
+    {
+        /// <summary>
+        /// <see cref="char"/> that delimit segments.
+        /// for use with <see cref="NHapi.Base.SupportClass.Tokenizer"/>.
+        /// </summary>
+        /// <remarks>
+        /// We are forgiving: HL7 2.3.1 section 2.7 says that carriage return <c>'\r'</c> is
+        /// the only segment delimiter.  TODO: check other versions.
+        /// </remarks>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "StyleCop.CSharp.NamingRules",
+            "SA1310:Field names should not contain underscore",
+            Justification = "Because these are constants and not just fields there is a rule clash.")]
+        private const string SEGMENT_SEPARATORS = "\r\n\f";
+
+        /// <summary>
+        /// Parse message and return data found with provided <see cref="DatumPath">DatumPaths</see>.
+        /// </summary>
+        /// <param name="message">Er7 encoded hl7 v2 message.</param>
+        /// <param name="messageMask">The location/path to retrieve values from.</param>
+        /// <param name="results">The values found in message.</param>
+        /// <returns>
+        /// <see langword="true"/> if parsed okay i.e. looks like Er7 encoded HL7.
+        /// <para>
+        /// We just barely check against HL7 structure, and ignore any elements / text that is unexpected
+        /// (that is, impossible in any HL7 message: independent of any message / segment definitions).
+        /// </para>
+        /// </returns>
+        public static bool ParseMessage(string message, IList<DatumPath> messageMask, out IDictionary<string, string> results)
+        {
+            messageMask ??= new List<DatumPath> { new () };
+            results = new Dictionary<string, string>();
+
+#if NET35
+            if (string.IsNullOrEmpty(message) || message.Trim().Length == 0)
+#else
+            if (string.IsNullOrWhiteSpace(message))
+#endif
+            {
+                return false;
+            }
+
+            var messageTokenizer = new SupportClass.Tokenizer(message, SEGMENT_SEPARATORS);
+
+            if (!messageTokenizer.HasMoreTokens())
+            {
+                return false;
+            }
+
+            var firstSegment = messageTokenizer.NextToken();
+
+            if (!ParseMshSegmentWhole(firstSegment, messageMask, results, out var encodingCharacters))
+            {
+                return false;
+            }
+
+            var segmentId2NextRepetitionIndex = new SortedDictionary<string, int> { { "MSH", 1 }, };
+
+            while (messageTokenizer.HasMoreTokens())
+            {
+                ParseSegmentWhole(
+                    segmentId2NextRepetitionIndex,
+                    messageMask,
+                    encodingCharacters,
+                    messageTokenizer.NextToken(),
+                    results);
+            }
+
+            return true;
+        }
+
+        private static bool ParseMshSegmentWhole(
+            string segment,
+            IList<DatumPath> messageMask,
+            IDictionary<string, string> results,
+            out EncodingCharacters encodingCharacters)
+        {
+            var result = false;
+            encodingCharacters = null;
+            try
+            {
+                encodingCharacters = new EncodingCharacters(
+                    segment[3],
+                    segment[4],
+                    segment[5],
+                    segment[6],
+                    segment[7]);
+
+                var handler = new Er7SegmentHandler(encodingCharacters, results)
+                {
+                    SegmentId = "MSH", SegmentRepetitionIndex = 0,
+                    MessageMasks = messageMask ?? new List<DatumPath> { new () },
+                };
+
+                var nodeKey = new List<int> { 0 };
+                handler.PutDatum(nodeKey, encodingCharacters.FieldSeparator.ToString());
+                nodeKey.Insert(0, 1);
+                handler.PutDatum(nodeKey, encodingCharacters.ToString());
+
+                if (segment[8] == encodingCharacters.FieldSeparator)
+                {
+                    result = true;
+
+                    nodeKey.Clear();
+                    nodeKey.Add(2);
+                    ParseSegmentGuts(handler, segment.Substring(9), nodeKey);
+                }
+            }
+            catch (IndexOutOfRangeException)
+            {
+            }
+            catch (ArgumentNullException)
+            {
+            }
+
+            return result;
+        }
+
+        private static void ParseSegmentGuts(Er7SegmentHandler handler, string guts, IList<int> nodeKey)
+        {
+            var lastIndex = nodeKey.Count - 1;
+            var thisDepthsDelim = handler.Delimiter(lastIndex);
+
+            var gutsTokenizer = new SupportClass.Tokenizer(guts, thisDepthsDelim.ToString(), true);
+            while (gutsTokenizer.HasMoreTokens())
+            {
+                var gutsToken = gutsTokenizer.NextToken();
+
+                if (gutsToken[0] == thisDepthsDelim)
+                {
+                    var oldValue = nodeKey[lastIndex];
+                    nodeKey[lastIndex] = oldValue + gutsToken.Length;
+                }
+                else
+                {
+                    if (nodeKey.Count < handler.SpecDepth)
+                    {
+                        nodeKey.Add(0);
+                        ParseSegmentGuts(handler, gutsToken, nodeKey);
+                        nodeKey.RemoveAt(nodeKey.Count - 1);
+                    }
+                    else
+                    {
+                        handler.PutDatum(nodeKey, gutsToken);
+                    }
+                }
+            }
+        }
+
+        private static void ParseSegmentWhole(
+            IDictionary<string, int> segmentId2NextRepetitionIndex,
+            IList<DatumPath> messageMask,
+            EncodingCharacters encodingCharacters,
+            string segment,
+            IDictionary<string, string> props)
+        {
+            try
+            {
+                if (encodingCharacters is null)
+                {
+                    throw new ArgumentNullException(nameof(encodingCharacters));
+                }
+
+                var segmentId = segment.Substring(0, 3);
+
+                var currentSegmentRepetitionIndex = segmentId2NextRepetitionIndex.ContainsKey(segmentId)
+                    ? segmentId2NextRepetitionIndex[segmentId]
+                    : 0;
+
+                segmentId2NextRepetitionIndex[segmentId] = currentSegmentRepetitionIndex + 1;
+
+                var segmentIdAsDatumPath = new DatumPath().Add(segmentId);
+                var parseThisSegment = messageMask.Any(m => segmentIdAsDatumPath.StartsWith(m));
+
+                parseThisSegment = messageMask.Any(m => m.StartsWith(segmentIdAsDatumPath) && !parseThisSegment);
+
+                if (parseThisSegment && (segment[3] == encodingCharacters.FieldSeparator))
+                {
+                    var handler = new Er7SegmentHandler(encodingCharacters, props)
+                    {
+                        SegmentId = segmentId,
+                        MessageMasks = messageMask,
+                        SegmentRepetitionIndex = currentSegmentRepetitionIndex,
+                    };
+
+                    var nodeKey = new List<int> { 0 };
+                    ParseSegmentGuts(handler, segment.Substring(4), nodeKey);
+                }
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+            }
+            catch (ArgumentNullException)
+            {
+            }
+        }
+
+        private class Er7SegmentHandler
+        {
+            internal int SegmentRepetitionIndex;
+            internal string SegmentId;
+            internal IList<DatumPath> MessageMasks;
+
+            private readonly EncodingCharacters encodingCharacters;
+            private readonly IDictionary<string, string> props;
+
+            public Er7SegmentHandler(EncodingCharacters encodingCharacters, IDictionary<string, string> props)
+            {
+                this.encodingCharacters = encodingCharacters;
+                this.props = props;
+            }
+
+            public int SpecDepth => 4;
+
+            public char Delimiter(int level) => level switch
+            {
+                0 => this.encodingCharacters.FieldSeparator,
+                1 => this.encodingCharacters.RepetitionSeparator,
+                2 => this.encodingCharacters.ComponentSeparator,
+                3 => this.encodingCharacters.SubcomponentSeparator,
+                _ => throw new ArgumentOutOfRangeException()
+            };
+
+            public void PutDatum(IList<int> valNodeKey, string value)
+            {
+                var valDatumPath = new DatumPath();
+                valDatumPath.Add(this.SegmentId).Add(this.SegmentRepetitionIndex);
+                for (var i = 0; i < valNodeKey.Count && valDatumPath.Size < 6; i++)
+                {
+                    valDatumPath.Add(i == 1 ? valNodeKey[i] : valNodeKey[i] + 1);
+                }
+
+                if (this.MessageMasks.Any(m => valDatumPath.StartsWith(m)))
+                {
+                    props.Add(valDatumPath.ToString(), value);
+                }
+            }
+        }
+    }
+}

--- a/src/NHapi.Base/PreParser/Er7.cs
+++ b/src/NHapi.Base/PreParser/Er7.cs
@@ -59,7 +59,7 @@ namespace NHapi.Base.PreParser
         /// (that is, impossible in any HL7 message: independent of any message / segment definitions).
         /// </para>
         /// </returns>
-        public static bool ParseMessage(string message, IList<DatumPath> messageMask, out IDictionary<string, string> results)
+        public static bool TryParseMessage(string message, IList<DatumPath> messageMask, out IDictionary<string, string> results)
         {
             messageMask ??= new List<DatumPath> { new () };
             results = new Dictionary<string, string>();
@@ -141,9 +141,11 @@ namespace NHapi.Base.PreParser
             }
             catch (IndexOutOfRangeException)
             {
+                // do nothing
             }
             catch (ArgumentNullException)
             {
+                // do nothing
             }
 
             return result;
@@ -222,9 +224,11 @@ namespace NHapi.Base.PreParser
             }
             catch (ArgumentOutOfRangeException)
             {
+                // do nothing
             }
             catch (ArgumentNullException)
             {
+                // do nothing
             }
         }
 

--- a/src/NHapi.Base/PreParser/PreParser.cs
+++ b/src/NHapi.Base/PreParser/PreParser.cs
@@ -64,11 +64,11 @@ namespace NHapi.Base.PreParser
             IDictionary<string, string> results;
             if (EncodingDetector.IsEr7Encoded(message))
             {
-                result = Er7.ParseMessage(message, datumPaths, out results);
+                result = Er7.TryParseMessage(message, datumPaths, out results);
             }
             else if (EncodingDetector.IsXmlEncoded(message))
             {
-                result = Xml.ParseMessage(message, datumPaths, out results);
+                result = Xml.TryParseMessage(message, datumPaths, out results);
             }
             else
             {

--- a/src/NHapi.Base/PreParser/PreParser.cs
+++ b/src/NHapi.Base/PreParser/PreParser.cs
@@ -1,0 +1,86 @@
+﻿/*
+  The contents of this file are subject to the Mozilla Public License Version 1.1
+  (the "License"); you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at http://www.mozilla.org/MPL/
+  Software distributed under the License is distributed on an "AS IS" basis,
+  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+  specific language governing rights and limitations under the License.
+
+  The Original Code is "PreParser.java".  Description:
+  "Extracts specified fields from unparsed messages. This class is a facade for the ER7 and XML classes."
+
+  The Initial Developer of the Original Code is University Health Network. Copyright (C)
+  2001.  All Rights Reserved.
+
+  Contributor(s): James, Agnew, Christian Ohr, Jake Aitchison
+
+  Alternatively, the contents of this file may be used under the terms of the
+  GNU General Public License (the "GPL"), in which case the provisions of the GPL are
+  applicable instead of those above.  If you wish to allow use of your version of this
+  file only under the terms of the GPL and not to allow others to use your version
+  of this file under the MPL, indicate your decision by deleting  the provisions above
+  and replace  them with the notice and other provisions required by the GPL License.
+  If you do not delete the provisions above, a recipient may use your version of
+  this file under either the MPL or the GPL.
+*/
+
+namespace NHapi.Base.PreParser
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using NHapi.Base.Parser;
+
+    /// <summary>
+    /// Extracts specified fields from unparsed messages.
+    /// <example>
+    /// <code>
+    /// var message = null; //... your ER7 or XML message string goes here
+    /// var fieldSpecs = new string[] { "MSH-9-1", "MSH-9-2", "MSH-12" };
+    /// var fields = PreParser.GetFields(message, fieldSpecs);
+    /// </code>
+    /// </example>
+    /// <remarks>This class is a facade for the <see cref="Er7"/> and <see cref="Xml"/> classes.</remarks>
+    /// </summary>
+    public static class PreParser
+    {
+        /// <summary>
+        /// Extracts selected fields from a message.
+        /// </summary>
+        /// <param name="message">An unparsed message from which to get fields.</param>
+        /// <param name="pathSpecs">
+        /// Terser-like paths to fields in the message.
+        /// See documentation for <see cref="NHapi.Base.Util.Terser"/>.
+        /// These paths are identical except that they start with the segment name (search flags and group
+        /// names are to be omitted as they are not relevant with unparsed ER7 messages).
+        /// </param>
+        /// <returns>Field values corresponding to the given paths.</returns>
+        /// <exception cref="HL7Exception">When detecting message encoding fails or when parsing the message fails.</exception>
+        public static string[] GetFields(string message, params string[] pathSpecs)
+        {
+            var datumPaths = pathSpecs.Select(x => x.FromPathSpec()).ToList();
+
+            bool result;
+            IDictionary<string, string> results;
+            if (EncodingDetector.IsEr7Encoded(message))
+            {
+                result = Er7.ParseMessage(message, datumPaths, out results);
+            }
+            else if (EncodingDetector.IsXmlEncoded(message))
+            {
+                result = Xml.ParseMessage(message, datumPaths, out results);
+            }
+            else
+            {
+                throw new HL7Exception("Message encoding is not recognized");
+            }
+
+            if (!result)
+            {
+                throw new HL7Exception("Parse failed");
+            }
+
+            return results.Select(x => x.Value).ToArray();
+        }
+    }
+}

--- a/src/NHapi.Base/PreParser/Xml.cs
+++ b/src/NHapi.Base/PreParser/Xml.cs
@@ -44,7 +44,7 @@ namespace NHapi.Base.PreParser
         /// for the location where the data is found (i.e. in the <c>ZYX[a]-b[c]-d-e</c> style), and the value
         /// being that of the corresponding text.
         /// </para>
-        /// <para>So, after calling <see cref="ParseMessage"/> successfully, if you wanted to retrieve the
+        /// <para>So, after calling <see cref="TryParseMessage"/> successfully, if you wanted to retrieve the
         /// message data from <paramref name="results"/> you might call something like:
         /// <code>
         /// var key = new DatumPath().Add("MSH").Add(1).ToString();
@@ -114,7 +114,7 @@ namespace NHapi.Base.PreParser
         /// (that is, impossible in any HL7 message: independent of any message / segment definitions).
         /// </para>
         /// </returns>
-        public static bool ParseMessage(string message, IEnumerable<DatumPath> messageMasks, out IDictionary<string, string> results)
+        public static bool TryParseMessage(string message, IEnumerable<DatumPath> messageMasks, out IDictionary<string, string> results)
         {
             results = new Dictionary<string, string>();
             messageMasks ??= new List<DatumPath> { new () };
@@ -128,8 +128,7 @@ namespace NHapi.Base.PreParser
                     var result = SearchForDatum(document, datumPath);
                     if (result is not null)
                     {
-                        var key = datumPath.Size == 0 ? "null DatumPath" : datumPath.ToString();
-                        results.Add(key, result);
+                        results.Add(datumPath.ToString(), result);
                     }
                 }
             }

--- a/src/NHapi.Base/PreParser/Xml.cs
+++ b/src/NHapi.Base/PreParser/Xml.cs
@@ -1,0 +1,180 @@
+﻿/*
+  The contents of this file are subject to the Mozilla Public License Version 1.1
+  (the "License"); you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at http://www.mozilla.org/MPL/
+  Software distributed under the License is distributed on an "AS IS" basis,
+  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+  specific language governing rights and limitations under the License.
+
+  Contributor(s): Jake Aitchison
+
+  Alternatively, the contents of this file may be used under the terms of the
+  GNU General Public License (the "GPL"), in which case the provisions of the GPL are
+  applicable instead of those above.  If you wish to allow use of your version of this
+  file only under the terms of the GPL and not to allow others to use your version
+  of this file under the MPL, indicate your decision by deleting  the provisions above
+  and replace  them with the notice and other provisions required by the GPL License.
+  If you do not delete the provisions above, a recipient may use your version of
+  this file under either the MPL or the GPL.
+*/
+namespace NHapi.Base.PreParser
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Xml.Linq;
+
+    public static class Xml
+    {
+        /// <summary>
+        /// Parse message and return data found with provided <see cref="DatumPath">DatumPaths</see>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <paramref name="message"/> should be an XML document with one top level element, that being the
+        /// message i.e. <![CDATA[<ACK>]]> or whatever.
+        /// </para>
+        /// <para>
+        /// We are only expecting one message / xml document to be in the<paramref name="message"/>.
+        /// </para>
+        /// <para>
+        /// The <paramref name="message"/> data (located via passed in <paramref name="messageMasks"/>) will be added to
+        /// <paramref name="results"/> as key / value pairs with the key being
+        /// <see cref="DatumPath.ToString()">DatumPath.ToString()</see> of the appropriate <see cref="DatumPath" />
+        /// for the location where the data is found (i.e. in the <c>ZYX[a]-b[c]-d-e</c> style), and the value
+        /// being that of the corresponding text.
+        /// </para>
+        /// <para>So, after calling <see cref="ParseMessage"/> successfully, if you wanted to retrieve the
+        /// message data from <paramref name="results"/> you might call something like:
+        /// <code>
+        /// var key = new DatumPath().Add("MSH").Add(1).ToString();
+        /// results.TryGetValue(key, out var @value)</code>
+        /// and that would return a String with "|", probably.
+        /// </para>
+        /// <para>
+        /// Note that this package facilitates the extraction of message data in a way
+        /// independent of message version (i.e. components and whatever getting added):
+        /// </para>
+        /// <para>
+        /// With a <paramref name="message" /> of <![CDATA[<FOO><ZYX><ZYX.42>fieldy-field-field</ZYX.42></ZYX></FOO>]]>,
+        /// <c>ZYX[0]-1[0]-1-1</c> will be the key that ends up in <paramref name="results"/> (see notes at
+        /// <see cref="DatumPath.ToString()">DatumPath.ToString()</see>).
+        /// </para>
+        /// <para>
+        /// So if you, coding for a future version of the FOO message but receiving an old-version message data,
+        /// tried:
+        /// <code>
+        /// var key = new DatumPath().Add("ZYX").Add(0).Add(42).Add(0).Add(1).ToString();
+        /// results.TryGetValue(key, out var @value)</code> with the message above (that is, trying to extract a
+        /// repetition and component that aren't there), you would get <c>ZYX[0]-42[0]-1-1</c> mapping to
+        /// "fieldy-field-field" in the resulting <paramref name="results"/>.
+        /// </para>
+        /// <para>
+        /// If the <paramref name="message" /> was <![CDATA[<FOO><ZYX><ZYX.42><ARG.1>component data</ARG.1></ZYX.42></ZYX></FOO>]]>
+        /// and you, coding for an old version of this FOO message but receiving new-version FOO message data,
+        /// tried:
+        /// <code>
+        /// var key = new DatumPath().Add("ZYX").Add(0).Add(42).ToString();
+        /// results.TryGetValue(key, out var @value)</code> you would get <c>ZYX[0]-42[0]-1-1</c> mapping to
+        /// "component data" in the resulting <paramref name="results"/>.
+        /// </para>
+        /// <para>
+        /// <paramref name="messageMasks" /> lets you specify which parts of the message you want dumped to
+        /// <paramref name="results"/>. Passing in null gets you everything. Otherwise, <paramref name="messageMasks" />
+        /// elements should all be <see cref="DatumPath">DatumPaths</see>, and a particular part of the message
+        /// will be added to <paramref name="results"/> only if it's location, as represented by a
+        /// <see cref="DatumPath" />, starts with (as in <see cref="DatumPathExtensions.StartsWith">DatumPathExtensions.StartsWith</see>)
+        /// at least one element of <paramref name="messageMasks" />.
+        /// </para>
+        /// <para>So if one element of <paramref name="messageMasks" /> was a
+        /// <c>new DatumPath().Add("ZYX")</c>, then everything in all <c>ZYX</c> segment would get dumped to
+        /// <paramref name="results"/>. A <c>new DatumPath().Add("ZYX").Add(1)</c> would get only the first
+        /// repetitions of same (if there is one) dumped to <paramref name="results"/>. etc. etc.
+        /// </para>
+        /// <para>
+        /// Note that a <see cref="DatumPath" /> of <see cref="DatumPath.Size" /> == 0 in <paramref name="messageMasks" />
+        /// will get you everything, no matter what the other elements of <paramref name="messageMasks" /> are, because
+        /// all <see cref="DatumPath">DatumPaths</see> starts with the zero-length <see cref="DatumPath" />.
+        /// </para>
+        /// <para>
+        /// Segment group elements (eg. ADT_A01.PROCEDURE) are handled fine, but they aren't addressed in
+        /// <paramref name="messageMasks" /> or in the output in <paramref name="results"/> -- basically any element tags
+        /// at the level immediately inside the message element, and having a name that starts with the
+        /// message element name + '.', is ignored (meaning it's contents are dealt with the same as if the
+        /// start and end tags' just  wasn't there.).
+        /// </para>
+        /// </remarks>
+        /// <param name="message">Xml encoded HL7 v2 message.</param>
+        /// <param name="messageMasks">The location/path to retrieve values from.</param>
+        /// <param name="results">The values found in message.</param>
+        /// <returns>
+        /// <see langword="true"/> if parsed okay i.e. xml was well formed.
+        /// <para>
+        /// We just barely check against HL7 structure, and ignore any elements / text that is unexpected
+        /// (that is, impossible in any HL7 message: independent of any message / segment definitions).
+        /// </para>
+        /// </returns>
+        public static bool ParseMessage(string message, IEnumerable<DatumPath> messageMasks, out IDictionary<string, string> results)
+        {
+            results = new Dictionary<string, string>();
+            messageMasks ??= new List<DatumPath> { new () };
+
+            try
+            {
+                var document = XDocument.Parse(message);
+
+                foreach (var datumPath in messageMasks)
+                {
+                    var result = SearchForDatum(document, datumPath);
+                    if (result is not null)
+                    {
+                        var key = datumPath.Size == 0 ? "null DatumPath" : datumPath.ToString();
+                        results.Add(key, result);
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private static string SearchForDatum(XDocument message, DatumPath datumPath)
+        {
+            if (datumPath.Size == 0)
+            {
+                return message.Root?.Value;
+            }
+
+            var segment = datumPath.Get(0) as string;
+
+            var nameSpace = message.Root?.Name.Namespace;
+            var search =
+                message.Root?.Elements(nameSpace + segment)
+                    .ElementAt((int)datumPath.Get(1));
+
+            if (search?.HasElements == true)
+            {
+                search = search.Elements()
+                    .Where(x => x.Name.LocalName.EndsWith($"{(int)datumPath.Get(2)}"))
+                    .ElementAt((int)datumPath.Get(3));
+            }
+
+            if (search?.HasElements == true)
+            {
+                search = search.Elements()
+                    .SingleOrDefault(x => x.Name.LocalName.EndsWith($"{(int)datumPath.Get(4)}"));
+            }
+
+            if (search?.HasElements == true)
+            {
+                search = search.Elements()
+                    .SingleOrDefault(x => x.Name.LocalName.EndsWith($"{(int)datumPath.Get(5)}"));
+            }
+
+            return search?.Value;
+        }
+    }
+}

--- a/src/NHapi.Base/PreParser/Xml.cs
+++ b/src/NHapi.Base/PreParser/Xml.cs
@@ -151,7 +151,7 @@ namespace NHapi.Base.PreParser
 
             var nameSpace = message.Root?.Name.Namespace;
             var search =
-                message.Root?.Elements(nameSpace + segment)
+                message.Root?.Descendants(nameSpace + segment)
                     .ElementAt((int)datumPath.Get(1));
 
             if (search?.HasElements == true)

--- a/tests/NHapi.Base.NUnit/Llp/CharSetUtilityTests.cs
+++ b/tests/NHapi.Base.NUnit/Llp/CharSetUtilityTests.cs
@@ -1,6 +1,8 @@
 ﻿namespace NHapi.Base.NUnit.Llp
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using System.Text;
 
     using global::NUnit.Framework;
@@ -96,5 +98,61 @@
             // Assert
             Assert.AreEqual(expectedDotnetEncoding, result.BodyName);
         }
+
+        [TestCase("ASCII", "us-ascii")] // ASCII
+        [TestCase("8859/1", "iso-8859-1")] // Western European (ISO)
+        [TestCase("8859/2", "iso-8859-2")] // Central European (ISO)
+        [TestCase("8859/3", "iso-8859-3")] // Latin 3 (ISO)
+        [TestCase("8859/4", "iso-8859-4")] // Baltic (ISO)
+        [TestCase("8859/5", "iso-8859-5")] // Cyrillic (ISO)
+        [TestCase("8859/6", "iso-8859-6")] // Arabic (ISO)
+        [TestCase("8859/7", "iso-8859-7")] // Greek (ISO)
+        [TestCase("8859/8", "iso-8859-8")] // Hebrew (ISO-Visual)
+        [TestCase("8859/9", "iso-8859-9")] // Turkish (ISO)
+        [TestCase("8859/15", "iso-8859-15")] // Latin 9 (ISO)
+#if NET6_0_OR_GREATER
+        [TestCase("GB 18030-2000", "gb18030")] // Chinese Simplified (GB18030)
+#elif NETFRAMEWORK
+        [TestCase("GB 18030-2000", "GB18030")] // Chinese Simplified (GB18030)
+#endif
+        [TestCase("KS X 1001", "euc-kr")] // Korean (EUC)
+        [TestCase("BIG-5", "big5")] // Chinese Traditional (Big5)
+        [TestCase("UNICODE", "utf-8")]
+        [TestCase("UNICODE UTF-8", "utf-8")] // Unicode (UTF-8)
+        [TestCase("UNICODE UTF-16", "utf-16")] // Unicode
+        [TestCase("UNICODE UTF-32", "utf-32")] // Unicode (UTF-32)
+        public void CheckCharset_MessageIsBytes_WhenEncodingSupportByPlatform_ReturnsExpectedEncoding(string hl7CharSet, string expectedDotnetEncoding)
+        {
+            // Arrange
+            var encoding = Encoding.GetEncoding(expectedDotnetEncoding);
+            var bomBytes = GetBom(expectedDotnetEncoding);
+
+            var messageBytes = encoding.GetBytes(
+                $"MSH|^~\\&|XPress Arrival||||200610120839||ORU^R01|EBzH1711114101206|P|2.3|||AL|||{hl7CharSet}\r"
+                + "PID|1||1711114||Appt^Test||19720501||||||||||||001020006\r"
+                + "ORC|||||F\r"
+                + "OBR|1|||ehipack^eHippa Acknowlegment|||200610120839|||||||||00002^eProvider^Electronic|||||||||F\r"
+                + "OBX|1||||STValue||||||F\r");
+
+            var messageBytesWithBom = bomBytes.Concat(messageBytes).ToArray();
+
+            // Act
+            var result = CharSetUtility.CheckCharset(messageBytesWithBom);
+
+            // Assert
+            Assert.AreEqual(expectedDotnetEncoding, result.BodyName);
+        }
+
+#pragma warning disable SA1201
+        private static byte[] GetBom(string encoding) => encoding switch
+        {
+            "utf-8" => new byte[] { 0xEF, 0xBB, 0xBF },
+            "utf-16" => new byte[] { 0xFF, 0xFE }, // UTF-16LE
+            "utf-16BE" => new byte[] { 0xFE, 0xFF, 0xBF }, // UTF-16BE
+            "utf-32" => new byte[] { 0xFF, 0xFE, 0x00, 0x00 }, // UTF-32LE
+            "utf-32BE" => new byte[] { 0x00, 0x00, 0xFE, 0xFF }, // UTF-32BE
+            _ => Array.Empty<byte>()
+        };
     }
+#pragma warning restore SA1201
 }

--- a/tests/NHapi.Base.NUnit/Llp/CharSetUtilityTests.cs
+++ b/tests/NHapi.Base.NUnit/Llp/CharSetUtilityTests.cs
@@ -1,0 +1,100 @@
+﻿namespace NHapi.Base.NUnit.Llp
+{
+    using System;
+    using System.Text;
+
+    using global::NUnit.Framework;
+
+    using NHapi.Base.Llp;
+
+    [TestFixture]
+    public class CharSetUtilityTests
+    {
+#if NET6_0_OR_GREATER
+        public CharSetUtilityTests()
+        {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        }
+#endif
+
+        [TestCase("random")]
+        [TestCase("not supported")]
+        [TestCase("doesnt exist")]
+        [TestCase("bdba4f1a-4984-4c78-ba02-48c3fdaca4d2")]
+        [TestCase("##}}{}{}DANGER##}{{}")]
+        public void CheckCharset_WhenEncodingNotSupportByHl7Specification_ReturnsDefaultEncoding(string hl7CharSet)
+        {
+            // Arrange
+            var message =
+                $"MSH|^~\\&|XPress Arrival||||200610120839||ORU^R01|EBzH1711114101206|P|2.3|||AL|||{hl7CharSet}\r"
+                + "PID|1||1711114||Appt^Test||19720501||||||||||||001020006\r"
+                + "ORC|||||F\r"
+                + "OBR|1|||ehipack^eHippa Acknowlegment|||200610120839|||||||||00002^eProvider^Electronic|||||||||F\r"
+                + "OBX|1||||STValue||||||F\r";
+
+            // Act
+            var result = CharSetUtility.CheckCharset(message);
+
+            // Assert
+            Assert.AreEqual("us-ascii", result.BodyName);
+        }
+
+        [TestCase("ISO IR6")]
+        [TestCase("ISO IR14")]
+        [TestCase("ISO IR87")]
+        [TestCase("ISO IR159")]
+        [TestCase("CNS 11643-1992")]
+        public void CheckCharset_WhenEncodingNotSupportByPlatform_ThrowsArgumentException(string hl7CharSet)
+        {
+            // Arrange
+            var message =
+                $"MSH|^~\\&|XPress Arrival||||200610120839||ORU^R01|EBzH1711114101206|P|2.3|||AL|||{hl7CharSet}\r"
+                + "PID|1||1711114||Appt^Test||19720501||||||||||||001020006\r"
+                + "ORC|||||F\r"
+                + "OBR|1|||ehipack^eHippa Acknowlegment|||200610120839|||||||||00002^eProvider^Electronic|||||||||F\r"
+                + "OBX|1||||STValue||||||F\r";
+
+            // Act / Assert
+            Assert.Throws<ArgumentException>(() => CharSetUtility.CheckCharset(message));
+        }
+
+        [TestCase("ASCII", "us-ascii")] // ASCII
+        [TestCase("8859/1", "iso-8859-1")] // Western European (ISO)
+        [TestCase("8859/2", "iso-8859-2")] // Central European (ISO)
+        [TestCase("8859/3", "iso-8859-3")] // Latin 3 (ISO)
+        [TestCase("8859/4", "iso-8859-4")] // Baltic (ISO)
+        [TestCase("8859/5", "iso-8859-5")] // Cyrillic (ISO)
+        [TestCase("8859/6", "iso-8859-6")] // Arabic (ISO)
+        [TestCase("8859/7", "iso-8859-7")] // Greek (ISO)
+        [TestCase("8859/8", "iso-8859-8")] // Hebrew (ISO-Visual)
+        [TestCase("8859/9", "iso-8859-9")] // Turkish (ISO)
+        [TestCase("8859/15", "iso-8859-15")] // Latin 9 (ISO)
+#if NET6_0_OR_GREATER
+        [TestCase("GB 18030-2000", "gb18030")] // Chinese Simplified (GB18030)
+#elif NETFRAMEWORK
+        [TestCase("GB 18030-2000", "GB18030")] // Chinese Simplified (GB18030)
+#endif
+        [TestCase("KS X 1001", "euc-kr")] // Korean (EUC)
+        [TestCase("BIG-5", "big5")] // Chinese Traditional (Big5)
+        [TestCase("UNICODE", "utf-8")]
+        [TestCase("UNICODE UTF-8", "utf-8")] // Unicode (UTF-8)
+        [TestCase("UNICODE UTF-16", "utf-16")] // Unicode
+        [TestCase("UNICODE UTF-32", "utf-32")] // Unicode (UTF-32)
+        public void CheckCharset_WhenEncodingSupportByPlatform_ReturnsExpectedEncoding(string hl7CharSet, string expectedDotnetEncoding)
+        {
+            // Arrange
+            var message =
+                $"MSH|^~\\&|XPress Arrival||||200610120839||ORU^R01|EBzH1711114101206|P|2.3|||AL|||{hl7CharSet}\r"
+                + "PID|1||1711114||Appt^Test||19720501||||||||||||001020006\r"
+                + "ORC|||||F\r"
+                + "OBR|1|||ehipack^eHippa Acknowlegment|||200610120839|||||||||00002^eProvider^Electronic|||||||||F\r"
+                + "OBX|1||||STValue||||||F\r";
+
+            // Act
+            var result = CharSetUtility.CheckCharset(message);
+
+            // Assert
+            Assert.AreEqual(expectedDotnetEncoding, result.BodyName);
+        }
+    }
+}

--- a/tests/NHapi.Base.NUnit/Llp/Hl7CharSetsTests.cs
+++ b/tests/NHapi.Base.NUnit/Llp/Hl7CharSetsTests.cs
@@ -1,0 +1,81 @@
+﻿namespace NHapi.Base.NUnit.Llp
+{
+    using System;
+    using System.Text;
+
+    using global::NUnit.Framework;
+
+    using NHapi.Base.Llp;
+    using NHapi.Base.Parser;
+
+    [TestFixture]
+    public class Hl7CharSetsTests
+    {
+#if NET6_0_OR_GREATER
+        public Hl7CharSetsTests()
+        {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        }
+#endif
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("   ")]
+        public void FromHl7Encoding_InputIsNullEmptyOrWhiteSpace_ThrowsArgumentException(string input)
+        {
+            // Arrange / Act / Assert
+            Assert.Throws<ArgumentException>(() => Hl7CharSets.FromHl7Encoding(input));
+        }
+
+        [TestCase("UNKNOWN")]
+        [TestCase("NOT NOWN")]
+        [TestCase("KLJHJKLHHKLJ")]
+        public void FromHl7Encoding_InputIsNotKnownOrMapped_ThrowsEncodingNotSupportedException(string input)
+        {
+            // Arrange / Act / Assert
+            Assert.Throws<EncodingNotSupportedException>(() => Hl7CharSets.FromHl7Encoding(input));
+        }
+
+        [TestCase("ISO IR6")]
+        [TestCase("ISO IR14")]
+        [TestCase("ISO IR87")]
+        [TestCase("ISO IR159")]
+        [TestCase("CNS 11643-1992")]
+        public void CheckCharset_WhenEncodingNotSupportByPlatform_ThrowsArgumentException(string hl7CharSet)
+        {
+            // Arrange / Act / Assert
+            Assert.Throws<ArgumentException>(() => Hl7CharSets.FromHl7Encoding(hl7CharSet));
+        }
+
+        [TestCase("ASCII", "us-ascii")] // ASCII
+        [TestCase("8859/1", "iso-8859-1")] // Western European (ISO)
+        [TestCase("8859/2", "iso-8859-2")] // Central European (ISO)
+        [TestCase("8859/3", "iso-8859-3")] // Latin 3 (ISO)
+        [TestCase("8859/4", "iso-8859-4")] // Baltic (ISO)
+        [TestCase("8859/5", "iso-8859-5")] // Cyrillic (ISO)
+        [TestCase("8859/6", "iso-8859-6")] // Arabic (ISO)
+        [TestCase("8859/7", "iso-8859-7")] // Greek (ISO)
+        [TestCase("8859/8", "iso-8859-8")] // Hebrew (ISO-Visual)
+        [TestCase("8859/9", "iso-8859-9")] // Turkish (ISO)
+        [TestCase("8859/15", "iso-8859-15")] // Latin 9 (ISO)
+#if NET6_0_OR_GREATER
+        [TestCase("GB 18030-2000", "gb18030")] // Chinese Simplified (GB18030)
+#elif NETFRAMEWORK
+        [TestCase("GB 18030-2000", "GB18030")] // Chinese Simplified (GB18030)
+#endif
+        [TestCase("KS X 1001", "euc-kr")] // Korean (EUC)
+        [TestCase("BIG-5", "big5")] // Chinese Traditional (Big5)
+        [TestCase("UNICODE", "utf-8")]
+        [TestCase("UNICODE UTF-8", "utf-8")] // Unicode (UTF-8)
+        [TestCase("UNICODE UTF-16", "utf-16")] // Unicode
+        [TestCase("UNICODE UTF-32", "utf-32")] // Unicode (UTF-32)
+        public void CheckCharset_WhenEncodingSupportByPlatform_ReturnsExpectedEncoding(string hl7CharSet, string expectedDotnetEncoding)
+        {
+            // Arrange / Act
+            var result = Hl7CharSets.FromHl7Encoding(hl7CharSet);
+
+            // Assert
+            Assert.AreEqual(expectedDotnetEncoding, result.BodyName);
+        }
+    }
+}

--- a/tests/NHapi.Base.NUnit/NHapi.Base.NUnit.csproj
+++ b/tests/NHapi.Base.NUnit/NHapi.Base.NUnit.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net461;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/tests/NHapi.Base.NUnit/NHapi.Base.NUnit.csproj
+++ b/tests/NHapi.Base.NUnit/NHapi.Base.NUnit.csproj
@@ -32,6 +32,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\NHapi.Base\NHapi.Base.csproj" />
+    <ProjectReference Include="..\..\src\NHapi.Model.V26\NHapi.Model.V26.csproj" />
     <ProjectReference Include="..\..\src\NHapi.Model.V24\NHapi.Model.V24.csproj" />
     <ProjectReference Include="..\..\src\NHapi.Model.V22\NHapi.Model.V22.csproj" />
   </ItemGroup>

--- a/tests/NHapi.Base.NUnit/PreParser/DatumPathExtensionsTests.cs
+++ b/tests/NHapi.Base.NUnit/PreParser/DatumPathExtensionsTests.cs
@@ -1,0 +1,226 @@
+﻿namespace NHapi.Base.NUnit.PreParser
+{
+    using System;
+
+    using global::NUnit.Framework;
+
+    using NHapi.Base.PreParser;
+
+    [TestFixture]
+    public class DatumPathExtensionsTests
+    {
+        [TestCaseSource(nameof(startsWithTestCases))]
+        public void StartsWith_ValidInput_ReturnsExpectedResult(DatumPath inputA, DatumPath inputB, bool expected)
+        {
+            // Arrange / Act / Assert
+            Assert.AreEqual(expected, inputA.StartsWith(inputB));
+        }
+
+        [Test]
+        public void StartsWith_InputIsNull_ThrowsArgumentNullException()
+        {
+            // Arrange
+            var other = new DatumPath().Add("ZXY").Add(1).Add(2);
+
+            // Act / Assert
+            Assert.Throws<ArgumentNullException>(() => ((DatumPath)null).StartsWith(other));
+        }
+
+        [Test]
+        public void NumbersLessThan_InputIsNull_ThrowsArgumentNullException()
+        {
+            // Arrange
+            var other = new DatumPath().Add("ZXY").Add(1).Add(2);
+
+            // Act / Assert
+            Assert.Throws<ArgumentNullException>(() => ((DatumPath)null).NumbersLessThan(other));
+        }
+
+        [TestCaseSource(nameof(numbersLessThanTestCases))]
+        public void NumbersLessThan_ValidInput_ReturnsExpectedResult(DatumPath inputA, DatumPath inputB, bool expected)
+        {
+            // Arrange / Act / Assert
+            Assert.AreEqual(expected, inputA.NumbersLessThan(inputB), $"{inputA} !< {inputB}");
+        }
+
+        [Test]
+        public void FromPathSpec_PathIsNull_ThrowsArgumentNullException()
+        {
+            // Arrange / Act / Assert
+            Assert.Throws<ArgumentNullException>(() => (null as string).FromPathSpec());
+        }
+
+        [TestCase("not-a-valid-path")]
+        [TestCase("MSHY-0-0")]
+        [TestCase("PID-1-1-1-1-1")]
+        [TestCase("54CC83C2-2FAE-4B5E-A325-AF29596A9E94")]
+        [TestCase("db9aabf8-bed1-4303-956f-683c0e895854")]
+        public void FromPathSpec_InValidPath_ThrowsArgumentException(string input)
+        {
+            // Arrange / Act / Assert
+            Assert.Throws<ArgumentException>(() => input.FromPathSpec());
+        }
+
+        [TestCaseSource(nameof(fromPathSpecTestCases))]
+        public void FromPathSpec_ValidPath_ReturnsExpectedDatumPath(string input, DatumPath expected)
+        {
+            // Arrange / Act
+            var actual = input.FromPathSpec();
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+#pragma warning disable SA1313
+        [TestCaseSource(nameof(fromPathSpecTestCases))]
+        public void FromPathSpec_FromPathSpecOriginal_AreEqual(string input, DatumPath _)
+        {
+            // Arrange / Act
+            var actual = input.FromPathSpec();
+            var expected = input.FromPathSpecOriginal();
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+        }
+#pragma warning restore SA1313
+#pragma warning disable SA1201
+
+        private static object[] fromPathSpecTestCases =
+        {
+            new object[]
+            {
+                "MSH-9-1",
+                new DatumPath().Add("MSH").Add(0).Add(9).Add(0).Add(1).Add(1),
+            },
+            new object[]
+            {
+                "MSH-9(0)-1",
+                new DatumPath().Add("MSH").Add(0).Add(9).Add(0).Add(1).Add(1),
+            },
+            new object[]
+            {
+                "PID-5-1-1",
+                new DatumPath().Add("PID").Add(0).Add(5).Add(0).Add(1).Add(1),
+            },
+            new object[]
+            {
+                "NTE(0)-1-1",
+                new DatumPath().Add("NTE").Add(0).Add(1).Add(0).Add(1).Add(1),
+            },
+            new object[]
+            {
+                "NTE(0)-1(2)-3-234",
+                new DatumPath().Add("NTE").Add(0).Add(1).Add(2).Add(3).Add(234),
+            },
+        };
+
+        private static object[] startsWithTestCases =
+        {
+            new object[]
+            {
+                new DatumPath().Add("ZXY").Add(1).Add(1).Add(1).Add(1),
+                new DatumPath().Add("ZXY").Add(1).Add(1), true,
+            },
+            new object[]
+            {
+                new DatumPath().Add("ZXY").Add(1).Add(2).Add(1).Add(1),
+                new DatumPath().Add("ZXY").Add(1).Add(2).Add(1), true,
+            },
+            new object[]
+            {
+                new DatumPath().Add("ZXY").Add(1).Add(3).Add(5).Add(5),
+                new DatumPath().Add("ZXY").Add(1).Add(3),
+                true,
+            },
+            new object[]
+            {
+                new DatumPath().Add("ZXY").Add(1).Add(1),
+                new DatumPath().Add("ZXY").Add(1).Add(1),
+                true,
+            },
+            new object[]
+            {
+                new DatumPath().Add("ZXY").Add(1).Add(1).Add(1).Add(2),
+                new DatumPath().Add("ZXY").Add(1).Add(1).Add(1).Add(1), false,
+            },
+            new object[]
+            {
+                new DatumPath().Add("ZXY").Add(1).Add(2).Add(1).Add(2),
+                new DatumPath().Add("ZXY").Add(1).Add(3), false,
+            },
+            new object[]
+            {
+                new DatumPath().Add("ZXY").Add(1).Add(2),
+                new DatumPath().Add("ZXY").Add(1).Add(1).Add(5).Add(5),
+                false,
+            },
+            new object[]
+            {
+                new DatumPath().Add("ZXY").Add(1).Add(1).Add(5).Add(5),
+                new DatumPath().Add("ZXY").Add(1).Add(2),
+                false,
+            },
+            new object[]
+            {
+                new DatumPath().Add("ZXY").Add(1).Add(1).Add(5).Add(5),
+                null,
+                false,
+            },
+        };
+
+        private static object[] numbersLessThanTestCases =
+        {
+            new object[]
+            {
+                new DatumPath().Add("ZXY").Add(1).Add(1).Add(1).Add(1),
+                new DatumPath().Add("ZXY").Add(1).Add(1).Add(1).Add(2), true,
+            },
+            new object[]
+            {
+                new DatumPath().Add("ZXY").Add(1).Add(2).Add(1).Add(1),
+                new DatumPath().Add("ZXY").Add(1).Add(2).Add(1).Add(2), true,
+            },
+            new object[]
+            {
+                new DatumPath().Add("ZXY").Add(1).Add(1).Add(5).Add(5),
+                new DatumPath().Add("ZXY").Add(1).Add(2),
+                true,
+            },
+            new object[]
+            {
+                new DatumPath().Add("ZXY").Add(1).Add(1),
+                new DatumPath().Add("ZXY").Add(1).Add(1).Add(5).Add(5),
+                true,
+            },
+            new object[]
+            {
+                new DatumPath().Add("ZXY").Add(1).Add(1).Add(1).Add(2),
+                new DatumPath().Add("ZXY").Add(1).Add(1).Add(1).Add(1), false,
+            },
+            new object[]
+            {
+                new DatumPath().Add("ZXY").Add(1).Add(2).Add(1).Add(2),
+                new DatumPath().Add("ZXY").Add(1).Add(2).Add(1).Add(1), false,
+            },
+            new object[]
+            {
+                new DatumPath().Add("ZXY").Add(1).Add(2),
+                new DatumPath().Add("ZXY").Add(1).Add(1).Add(5).Add(5),
+                false,
+            },
+            new object[]
+            {
+                new DatumPath().Add("ZXY").Add(1).Add(1).Add(5).Add(5),
+                new DatumPath().Add("ZXY").Add(1).Add(1),
+                false,
+            },
+            new object[]
+            {
+                new DatumPath().Add("ZXY").Add(1).Add(1).Add(5).Add(5),
+                null,
+                false,
+            },
+        };
+#pragma warning restore SA1201
+    }
+}

--- a/tests/NHapi.Base.NUnit/PreParser/DatumPathTests.cs
+++ b/tests/NHapi.Base.NUnit/PreParser/DatumPathTests.cs
@@ -298,14 +298,6 @@
             Assert.AreEqual(!expected, inputA != inputB);
         }
 
-        [Test]
-        public void ToString_SizeIsEqualTo0_ThrowsArgumentOutOfRangeException()
-        {
-            // Arrange
-            // Act / Assert
-            Assert.Throws<ArgumentOutOfRangeException>(() => new DatumPath().ToString());
-        }
-
         [TestCaseSource(nameof(toStringTestCases))]
         public void ToString_ValidInput_ReturnsExpectedValue(DatumPath input, string expected)
         {
@@ -409,6 +401,7 @@
             new object[] { new DatumPath().Add("ZXY").Add(1).Add(5), "ZXY[1]-5[0]-1-1", },
             new object[] { new DatumPath().Add("ZXY").Add(1).Add(2).Add(3).Add(4), "ZXY[1]-2[3]-4-1", },
             new object[] { new DatumPath().Add("ZXY").Add(4).Add(3).Add(2).Add(1), "ZXY[4]-3[2]-1-1", },
+            new object[] { new DatumPath(), "???[?]-?[?]-?-?", },
         };
 #pragma warning restore SA1201
     }

--- a/tests/NHapi.Base.NUnit/PreParser/DatumPathTests.cs
+++ b/tests/NHapi.Base.NUnit/PreParser/DatumPathTests.cs
@@ -1,0 +1,415 @@
+﻿namespace NHapi.Base.NUnit.PreParser
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+
+    using global::NUnit.Framework;
+
+    using NHapi.Base.PreParser;
+
+    [TestFixture]
+    public class DatumPathTests
+    {
+        [TestCase(1)]
+        [TestCase(20)]
+        [TestCase(6)]
+        [TestCase(0)]
+        public void Add_Int_SizeIsLessThan1_ThrowsInvalidOperationException(int value)
+        {
+            // Arrange
+            var sut = new DatumPath();
+
+            // Act / Assert
+            Assert.Throws<InvalidOperationException>(() => sut.Add(1));
+        }
+
+        [Test]
+        public void Add_Int_SizeIsEqualTo6_ThrowsArgumentOutOfRangeException()
+        {
+            // Arrange
+            var sut =
+                new DatumPath()
+                    .Add("ZXY")
+                    .Add(1)
+                    .Add(1)
+                    .Add(1)
+                    .Add(1)
+                    .Add(1);
+
+            // Act / Assert
+            Assert.Throws<ArgumentOutOfRangeException>(() => sut.Add(1));
+        }
+
+        [Test]
+        public void Add_Int_SizeIsGreaterThen0_AddsValueToPath()
+        {
+            // Arrange
+            var sut =
+                new DatumPath()
+                    .Add("ZXY");
+
+            // Act / Assert
+            Assert.DoesNotThrow(() => sut.Add(1));
+        }
+
+        [TestCase("ZXY")]
+        [TestCase("ABC")]
+        [TestCase("dkldjsf")]
+        [TestCase("65454sadad")]
+        public void Add_String_SizeIsGreaterThen0_ThrowsInvalidOperationException(string input)
+        {
+            // Arrange
+            var sut =
+                new DatumPath()
+                    .Add("ZXY");
+
+            // Act / Assert
+            Assert.Throws<InvalidOperationException>(() => sut.Add(input));
+        }
+
+        [Test]
+        public void Add_String_SizeIs0_AddsValueToPath()
+        {
+            // Arrange
+            var sut = new DatumPath();
+
+            // Act / Assert
+            Assert.DoesNotThrow(() => sut.Add("ZXY"));
+        }
+
+        [TestCase(-1)]
+        [TestCase(-10)]
+        [TestCase(-7)]
+        [TestCase(-80)]
+        [TestCase(-999)]
+        public void Set_Int_IndexIsLess0_ThrowsArgumentOutOfRangeException(int input)
+        {
+            // Arrange
+            var sut = new DatumPath();
+
+            // Act / Assert
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => sut.Set(input, 1));
+        }
+
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(3)]
+        [TestCase(4)]
+        [TestCase(5)]
+        [TestCase(6)]
+        public void Set_Int_GreaterThanOrEqualToSize_ThrowsArgumentOutOfRangeException(int input)
+        {
+            // Arrange
+            var sut = new DatumPath();
+
+            // Act / Assert
+            Assert.GreaterOrEqual(input, sut.Size);
+            Assert.Throws<ArgumentOutOfRangeException>(() => sut.Set(input, 1));
+        }
+
+        [TestCase(7)]
+        [TestCase(8)]
+        [TestCase(9)]
+        [TestCase(80)]
+        [TestCase(999)]
+        public void Set_Int_GreaterThanOrEqualTo6_ThrowsArgumentOutOfRangeException(int input)
+        {
+            // Arrange
+            var sut = new DatumPath();
+
+            // Act / Assert
+            Assert.GreaterOrEqual(input, 6);
+            Assert.Throws<ArgumentOutOfRangeException>(() => sut.Set(input, 1));
+        }
+
+        [Test]
+        public void Set_Int_IndexIs0_ThrowsArgumentException()
+        {
+            // Arrange
+            var sut =
+                new DatumPath()
+                    .Add("ZXY");
+
+            // Act / Assert
+            Assert.Throws<ArgumentException>(() => sut.Set(0, 1));
+        }
+
+        [Test]
+        public void Set_Int_NewValueIsNull_ThrowsArgumentNullException()
+        {
+            // Arrange
+            var sut =
+                new DatumPath()
+                    .Add("ZXY")
+                    .Add(2);
+
+            // Act / Assert
+            Assert.Throws<ArgumentNullException>(() => sut.Set(1, (int?)null));
+        }
+
+        [Test]
+        public void Set_Int_InputIsValid_InsertsValueAtIndex()
+        {
+            // Arrange
+            var index = 1;
+            var expected = 10;
+            var sut =
+                new DatumPath()
+                    .Add("ZXY")
+                    .Add(2);
+
+            // Act
+            sut.Set(index, 10);
+
+            // Assert
+            Assert.AreEqual(expected, sut.Get(index));
+        }
+
+        [TestCase(-1)]
+        [TestCase(-10)]
+        [TestCase(1)]
+        [TestCase(10)]
+        [TestCase(7)]
+        [TestCase(80)]
+        [TestCase(999)]
+        public void Set_String_IndexDoesNotEqual0_ThrowsArgumentException(int input)
+        {
+            // Arrange
+            var sut = new DatumPath();
+
+            // Act / Assert
+            Assert.AreNotEqual(0, input);
+            Assert.Throws<ArgumentException>(() => sut.Set(input, "ZXY"));
+        }
+
+        [Test]
+        public void Set_String_NewValueIsNull_ThrowsArgumentNullException()
+        {
+            // Arrange
+            var sut = new DatumPath();
+
+            // Act / Assert
+            Assert.Throws<ArgumentNullException>(() => sut.Set(0, (string)null));
+        }
+
+        [Test]
+        public void Set_String_InputIsValid_InsertsValueAtIndex()
+        {
+            // Arrange
+            var index = 0;
+            var expectedValue = "ABC";
+            var sut =
+                new DatumPath()
+                    .Add("ZXY")
+                    .Add(2);
+
+            // Act
+            sut.Set(index, expectedValue);
+
+            // Assert
+            Assert.AreEqual(expectedValue, sut.Get(index));
+        }
+
+        [Test]
+        public void ReSize_NewSizeIsGreaterThanMaxSize6_ThrowsArgumentOutOfRangeException()
+        {
+            // Arrange
+            var newSize = 7;
+            var sut = new DatumPath();
+
+            // Act / Assert
+            Assert.Throws<ArgumentOutOfRangeException>(() => sut.ReSize(newSize));
+        }
+
+        [Test]
+        public void ReSize_NewSizeIsGreaterThanSize_SetsDefaultValues()
+        {
+            // Arrange
+            var newSize = 6;
+            var sut = new DatumPath();
+
+            var expected =
+                new DatumPath()
+                    .Add(string.Empty)
+                    .Add(0)
+                    .Add(1)
+                    .Add(0)
+                    .Add(1)
+                    .Add(1);
+
+            // Act
+            Assert.GreaterOrEqual(newSize, sut.Size);
+            sut.ReSize(newSize);
+
+            // Assert
+            Assert.AreEqual(expected, sut);
+        }
+
+        [Test]
+        public void ReSize_NewSizeIsLessThanSize_DropsAdditionalValues()
+        {
+            // Arrange
+            var newSize = 2;
+            var sut =
+                new DatumPath()
+                    .Add(string.Empty)
+                    .Add(0)
+                    .Add(1)
+                    .Add(0)
+                    .Add(1)
+                    .Add(1);
+
+            var expected =
+                new DatumPath()
+                    .Add(string.Empty)
+                    .Add(0);
+
+            // Act
+            Assert.Less(newSize, sut.Size);
+            sut.ReSize(newSize);
+
+            // Assert
+            Assert.AreEqual(expected, sut);
+        }
+
+        [TestCaseSource(nameof(equalityTestCases))]
+        public void Equals_InputsAreEqual_ReturnsExpectedResult(DatumPath inputA, object inputB, bool expected)
+        {
+            // Arrange
+            // Act / Assert
+            Assert.AreEqual(expected, inputA.Equals(inputB));
+        }
+
+        [TestCaseSource(nameof(equalityTestCasesOperator))]
+        public void EqualsOperator_InputsValid_ReturnsExpectedResults(DatumPath inputA, DatumPath inputB, bool expected)
+        {
+            // Arrange
+            // Act / Assert
+            Assert.AreEqual(expected, inputA == inputB);
+        }
+
+        [TestCaseSource(nameof(equalityTestCasesOperator))]
+        public void NotEqualsOperator_InputsValid_ReturnsExpectedResults(DatumPath inputA, DatumPath inputB, bool expected)
+        {
+            // Arrange
+            // Act / Assert
+            Assert.AreEqual(!expected, inputA != inputB);
+        }
+
+        [Test]
+        public void ToString_SizeIsEqualTo0_ThrowsArgumentOutOfRangeException()
+        {
+            // Arrange
+            // Act / Assert
+            Assert.Throws<ArgumentOutOfRangeException>(() => new DatumPath().ToString());
+        }
+
+        [TestCaseSource(nameof(toStringTestCases))]
+        public void ToString_ValidInput_ReturnsExpectedValue(DatumPath input, string expected)
+        {
+            // Arrange
+            // Act / Assert
+            Assert.AreEqual(expected, input.ToString());
+        }
+
+        [Test]
+        public void Copy_PathValueIsNull_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var other = new DatumPath().Add("XXX");
+            var internalPath =
+                other.GetType()
+                    .GetField("path", BindingFlags.NonPublic | BindingFlags.Instance)
+                    ?.GetValue(other) as List<object>;
+
+            internalPath?.Add(null);
+
+            var sut = new DatumPath();
+
+            // Act / Assert
+            Assert.Throws<InvalidOperationException>(() => sut.Copy(other));
+        }
+
+        [Test]
+        public void Copy_PathValueIsNotStringOrInt_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var other = new DatumPath().Add("XXX");
+            var internalPath =
+                other.GetType()
+                    .GetField("path", BindingFlags.NonPublic | BindingFlags.Instance)
+                    ?.GetValue(other) as List<object>;
+
+            internalPath?.Add(DateTime.Now);
+
+            var sut = new DatumPath();
+
+            // Act / Assert
+            Assert.Throws<InvalidOperationException>(() => sut.Copy(other));
+        }
+
+        [Test]
+        public void Clear_ResetsDatumPathToDefaultState()
+        {
+            // Arrange
+            var sut =
+                new DatumPath()
+                    .Add("ZXY")
+                    .Add(2);
+
+            // Act
+            sut.Clear();
+
+            // Assert
+            Assert.AreEqual(new DatumPath(), sut);
+        }
+
+#pragma warning disable SA1201
+        private static object[] equalityTestCases =
+        {
+            new object[] { new DatumPath().Add("ZXY").Add(1).Add(2), new DatumPath().Add("ZXY").Add(1).Add(2), true, },
+            new object[]
+            {
+                new DatumPath().Add("ZXY").Add(1).Add(1).Add(1).Add(1),
+                new DatumPath().Add("ZXY").Add(1).Add(1).Add(1).Add(1), true,
+            },
+            new object[] { new DatumPath().Add("ZXY").Add(1).Add(2), null, false, },
+            new object[]
+            {
+                new DatumPath().Add("ZXY").Add(1).Add(1).Add(1).Add(1),
+                new DatumPath().Add("YXZ").Add(1).Add(1).Add(1).Add(1), false,
+            },
+            new object[] { new DatumPath().Add("ZXY").Add(1).Add(1).Add(1).Add(1), new { }, false, },
+        };
+
+        private static object[] equalityTestCasesOperator =
+        {
+            new object[] { new DatumPath().Add("ZXY").Add(1).Add(2), new DatumPath().Add("ZXY").Add(1).Add(2), true, },
+            new object[]
+            {
+                new DatumPath().Add("ZXY").Add(1).Add(1).Add(1).Add(1),
+                new DatumPath().Add("ZXY").Add(1).Add(1).Add(1).Add(1), true,
+            },
+            new object[] { new DatumPath().Add("ZXY").Add(1).Add(2), null, false, },
+            new object[]
+            {
+                new DatumPath().Add("ZXY").Add(1).Add(1).Add(1).Add(1),
+                new DatumPath().Add("YXZ").Add(1).Add(1).Add(1).Add(1), false,
+            },
+            new object[] { null, new DatumPath().Add("ZXY").Add(1).Add(1).Add(1).Add(1), false, },
+            new object[] { null, null, true },
+        };
+
+        private static object[] toStringTestCases =
+        {
+            new object[] { new DatumPath().Add("ZXY").Add(1).Add(2), "ZXY[1]-2[0]-1-1", },
+            new object[] { new DatumPath().Add("ZXY").Add(1).Add(0).Add(1).Add(1), "ZXY[1]-0[1]-1-1", },
+            new object[] { new DatumPath().Add("ZXY").Add(1).Add(5), "ZXY[1]-5[0]-1-1", },
+            new object[] { new DatumPath().Add("ZXY").Add(1).Add(2).Add(3).Add(4), "ZXY[1]-2[3]-4-1", },
+            new object[] { new DatumPath().Add("ZXY").Add(4).Add(3).Add(2).Add(1), "ZXY[4]-3[2]-1-1", },
+        };
+#pragma warning restore SA1201
+    }
+}

--- a/tests/NHapi.Base.NUnit/PreParser/Er7Tests.cs
+++ b/tests/NHapi.Base.NUnit/PreParser/Er7Tests.cs
@@ -1,0 +1,86 @@
+﻿namespace NHapi.Base.NUnit.PreParser
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using global::NUnit.Framework;
+
+    using NHapi.Base.PreParser;
+
+    [TestFixture]
+    public class Er7Tests
+    {
+        private const string MESSAGE = "MSH|^~\\&|x|x|x|x|199904140038||ADT^A01||P|2.2\r" +
+                                       "PID|||||Smith&Booth&Jones^X^Y\r" +
+                                       "NTE|a||one~two~three\r" +
+                                       "NTE|b||four\r";
+
+        [TestCase("MSH|")]
+        [TestCase("MSH|^")]
+        [TestCase("MSH|^~")]
+        [TestCase("MSH|^~\\")]
+        public void ParseMessage_MessageNotLongEnough_ReturnsFalse(string input)
+        {
+            // Arrange
+            var pathSpecs = Array.Empty<DatumPath>();
+
+            // Act
+            var result = Er7.ParseMessage(input, pathSpecs, out _);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("   ")]
+        public void ParseMessage_MessageIsNullEmptyOrWhiteSpace_ReturnsFalse(string input)
+        {
+            // Arrange
+            var pathSpecs = Array.Empty<DatumPath>();
+
+            // Act
+            var result = Er7.ParseMessage(input, pathSpecs, out _);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [TestCase("MSH|^~\\&|\rG")]
+        [TestCase("MSH|^~\\&|\rGR")]
+        public void ParseMessage_MessageSegmentIsTooShort_ArgumentOutOfRangeExceptionIsIgnored(string input)
+        {
+            // Arrange
+            var pathSpecs = Array.Empty<DatumPath>();
+
+            // Act
+            var result = Er7.ParseMessage(input, pathSpecs, out _);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [TestCase("NTE(0)-1", "a")]
+        [TestCase("NTE(1)-1", "b")]
+        [TestCase("NTE-3(0)", "one")]
+        [TestCase("NTE-3(1)", "two")]
+        [TestCase("PID-5", "Smith")]
+        [TestCase("PID-5-1-1", "Smith")]
+        [TestCase("MSH-9-2", "A01")]
+        [TestCase("PID-5-1-2", "Booth")]
+        public void ParseMessage_ValidADT_A01Er7_ReturnsExpectedResult(string pathSpec, string expectedValue)
+        {
+            // Arrange
+            var pathSpecs = new List<DatumPath> { pathSpec.FromPathSpec() };
+
+            // Act
+            var parsed = Er7.ParseMessage(MESSAGE, pathSpecs, out var results);
+            var actualResults = results.Select(r => r.Value).ToArray();
+
+            // Assert
+            Assert.True(parsed);
+            Assert.Contains(expectedValue, actualResults);
+        }
+    }
+}

--- a/tests/NHapi.Base.NUnit/PreParser/Er7Tests.cs
+++ b/tests/NHapi.Base.NUnit/PreParser/Er7Tests.cs
@@ -20,13 +20,13 @@
         [TestCase("MSH|^")]
         [TestCase("MSH|^~")]
         [TestCase("MSH|^~\\")]
-        public void ParseMessage_MessageNotLongEnough_ReturnsFalse(string input)
+        public void TryParseMessage_MessageNotLongEnough_ReturnsFalse(string input)
         {
             // Arrange
             var pathSpecs = Array.Empty<DatumPath>();
 
             // Act
-            var result = Er7.ParseMessage(input, pathSpecs, out _);
+            var result = Er7.TryParseMessage(input, pathSpecs, out _);
 
             // Assert
             Assert.False(result);
@@ -35,13 +35,13 @@
         [TestCase(null)]
         [TestCase("")]
         [TestCase("   ")]
-        public void ParseMessage_MessageIsNullEmptyOrWhiteSpace_ReturnsFalse(string input)
+        public void TryParseMessage_MessageIsNullEmptyOrWhiteSpace_ReturnsFalse(string input)
         {
             // Arrange
             var pathSpecs = Array.Empty<DatumPath>();
 
             // Act
-            var result = Er7.ParseMessage(input, pathSpecs, out _);
+            var result = Er7.TryParseMessage(input, pathSpecs, out _);
 
             // Assert
             Assert.False(result);
@@ -49,13 +49,13 @@
 
         [TestCase("MSH|^~\\&|\rG")]
         [TestCase("MSH|^~\\&|\rGR")]
-        public void ParseMessage_MessageSegmentIsTooShort_ArgumentOutOfRangeExceptionIsIgnored(string input)
+        public void TryParseMessage_MessageSegmentIsTooShort_ArgumentOutOfRangeExceptionIsIgnored(string input)
         {
             // Arrange
             var pathSpecs = Array.Empty<DatumPath>();
 
             // Act
-            var result = Er7.ParseMessage(input, pathSpecs, out _);
+            var result = Er7.TryParseMessage(input, pathSpecs, out _);
 
             // Assert
             Assert.True(result);
@@ -69,13 +69,13 @@
         [TestCase("PID-5-1-1", "Smith")]
         [TestCase("MSH-9-2", "A01")]
         [TestCase("PID-5-1-2", "Booth")]
-        public void ParseMessage_ValidADT_A01Er7_ReturnsExpectedResult(string pathSpec, string expectedValue)
+        public void TryParseMessage_ValidADT_A01Er7_ReturnsExpectedResult(string pathSpec, string expectedValue)
         {
             // Arrange
             var pathSpecs = new List<DatumPath> { pathSpec.FromPathSpec() };
 
             // Act
-            var parsed = Er7.ParseMessage(MESSAGE, pathSpecs, out var results);
+            var parsed = Er7.TryParseMessage(MESSAGE, pathSpecs, out var results);
             var actualResults = results.Select(r => r.Value).ToArray();
 
             // Assert

--- a/tests/NHapi.Base.NUnit/PreParser/PreParserTests.cs
+++ b/tests/NHapi.Base.NUnit/PreParser/PreParserTests.cs
@@ -1,0 +1,68 @@
+﻿// <copyright file="PreParserTests.cs" company="nHapiNET">
+// Copyright (c) nHapiNET. All rights reserved.
+// </copyright>
+
+namespace NHapi.Base.NUnit.PreParser
+{
+    using global::NUnit.Framework;
+
+    using NHapi.Base.PreParser;
+
+    [TestFixture]
+    public class PreParserTests
+    {
+        private const string ER7MESSAGE = "MSH|^~\\&|x|x|x|x|199904140038||ADT^A01||P|2.2\r" +
+                                       "PID|||||Smith&Booth&Jones^X^Y\r" +
+                                       "NTE|a||one~two~three\r" +
+                                       "NTE|b||four\r";
+
+        private const string XMLMESSAGE = "<?xml version=\"1.0\" standalone=\"no\"?><ADT_A01 xmlns=\"urn:hl7-org:v2xml\"><MSH><MSH.1>|</MSH.1><MSH.2>^~\\&amp;</MSH.2><MSH.3><HD.1>x</HD.1></MSH.3><MSH.4><HD.1>x</HD.1></MSH.4><MSH.5><HD.1>x</HD.1></MSH.5><MSH.6><HD.1>x</HD.1></MSH.6><MSH.7><TS.1>199904140038</TS.1></MSH.7><MSH.9><MSG.1>ADT</MSG.1><MSG.2>A01</MSG.2></MSH.9><MSH.11><PT.1>P</PT.1></MSH.11><MSH.12><VID.1>2.4</VID.1></MSH.12></MSH><PID><PID.5><XPN.1><FN.1>Smith</FN.1><FN.2>Booth</FN.2><FN.3>Jones</FN.3></XPN.1><XPN.2>X</XPN.2><XPN.3>Y</XPN.3></PID.5></PID><NTE><NTE.1>a</NTE.1><NTE.3>one</NTE.3><NTE.3>two</NTE.3><NTE.3>three</NTE.3></NTE><NTE><NTE.1>b</NTE.1><NTE.3>four</NTE.3></NTE></ADT_A01>";
+
+        [TestCase(null, "Message encoding is not recognized")]
+        [TestCase("", "Message encoding is not recognized")]
+        [TestCase("   ", "Message encoding is not recognized")]
+        [TestCase("NOTMSH", "Message encoding is not recognized")]
+        [TestCase("MSH|", "Parse failed")]
+        [TestCase("MSH.3", "Parse failed")]
+        public void GetFields_MessageIsInvalid_ThrowsHl7Exception(string message, string expectedExceptionMessage)
+        {
+            // Arrange / Act / Assert
+            var ex = Assert.Throws<HL7Exception>(() => PreParser.GetFields(message));
+            Assert.AreEqual(ex?.Message, expectedExceptionMessage);
+        }
+
+        [TestCase("NTE(0)-1", "a")]
+        [TestCase("NTE(1)-1", "b")]
+        [TestCase("NTE-3(0)", "one")]
+        [TestCase("NTE-3(1)", "two")]
+        [TestCase("PID-5", "Smith")]
+        [TestCase("PID-5-1-1", "Smith")]
+        [TestCase("MSH-9-2", "A01")]
+        [TestCase("PID-5-1-2", "Booth")]
+        public void GetFields_Er7MessageIsValid_ReturnsExpectedResult(string pathSpec, string expectedValue)
+        {
+            // Arrange / Act
+            var results = PreParser.GetFields(ER7MESSAGE, pathSpec);
+
+            // Assert
+            Assert.Contains(expectedValue, results);
+        }
+
+        [TestCase("NTE(0)-1", "a")]
+        [TestCase("NTE(1)-1", "b")]
+        [TestCase("NTE-3(0)", "one")]
+        [TestCase("NTE-3(1)", "two")]
+        [TestCase("PID-5", "Smith")]
+        [TestCase("PID-5-1-1", "Smith")]
+        [TestCase("MSH-9-2", "A01")]
+        [TestCase("PID-5-1-2", "Booth")]
+        public void GetFields_XmlMessageIsValid_ReturnsExpectedResult(string pathSpec, string expectedValue)
+        {
+            // Arrange / Act
+            var results = PreParser.GetFields(XMLMESSAGE, pathSpec);
+
+            // Assert
+            Assert.Contains(expectedValue, results);
+        }
+    }
+}

--- a/tests/NHapi.Base.NUnit/PreParser/XmlTests.cs
+++ b/tests/NHapi.Base.NUnit/PreParser/XmlTests.cs
@@ -12,7 +12,7 @@
     public class XmlTests
     {
         [Test]
-        public void ParseMessage_InvalidXml_ReturnsFalse()
+        public void TryParseMessage_InvalidXml_ReturnsFalse()
         {
             // Arrange
             var message = "6696A3E8-AEBE-4B7D-B2BB-3288261898A1";
@@ -20,14 +20,14 @@
             var pathSpecs = Array.Empty<DatumPath>();
 
             // Act
-            var parsed = Xml.ParseMessage(message, pathSpecs, out _);
+            var parsed = Xml.TryParseMessage(message, pathSpecs, out _);
 
             // Assert
             Assert.False(parsed);
         }
 
         [Test]
-        public void ParseMessage_ValidXml_ReturnsTrue()
+        public void TryParseMessage_ValidXml_ReturnsTrue()
         {
             // Arrange
             var message = "<?xml version=\"1.0\" standalone=\"no\"?><root><child>value</child></root>";
@@ -35,14 +35,14 @@
             var pathSpecs = Array.Empty<DatumPath>();
 
             // Act
-            var parsed = Xml.ParseMessage(message, pathSpecs, out _);
+            var parsed = Xml.TryParseMessage(message, pathSpecs, out _);
 
             // Assert
             Assert.True(parsed);
         }
 
         [Test]
-        public void ParseMessage_ValidXML_NullPathSpec_ReturnsExpectedResult()
+        public void TryParseMessage_ValidXML_NullPathSpec_ReturnsExpectedResult()
         {
             // Arrange
             const string message = "<?xml version=\"1.0\" standalone=\"no\"?> <QBP_Q22>  <MSH>   <MSH.1>|</MSH.1>   <MSH.2>^~/&amp;</MSH.2>   <MSH.3>    <HD.1>UHN Vista</HD.1>    <HD.3>ISO</HD.3>   </MSH.3>   <MSH.4>    <HD.1>UHN</HD.1>    <HD.3>ISO</HD.3>   </MSH.4>   <MSH.5>    <HD.1>MPI</HD.1>    <HD.3>ISO</HD.3>   </MSH.5>   <MSH.6>    <HD.1>HealthLink</HD.1>    <HD.3>ISO</HD.3>   </MSH.6>   <MSH.7>20020429132718.734-0400</MSH.7>   <MSH.9>    <CM_MSG_TYPE.1>QBP</CM_MSG_TYPE.1>    <CM_MSG_TYPE.2>Q22</CM_MSG_TYPE.2>  <CM_MSG_TYPE.3>QBP_Q21</CM_MSG_TYPE.3>   </MSH.9>   <MSH.10>855</MSH.10>   <MSH.11>    <PT.1>P</PT.1>   </MSH.11>   <MSH.12>    <VID.1>2.4</VID.1>      </MSH.12>   <MSH.21>Q22</MSH.21>  </MSH>  <QPD>   <QPD.1>    <CE.1>Q22</CE.1>    <CE.2>Find Candidates</CE.2>    <CE.3>HL7nnnn</CE.3>   </QPD.1>   <QPD.3><QIP><QIP.1>@PID.3.1</QIP.1><QIP.2>9583518684</QIP.2></QIP><QIP><QIP.1>@PID.3.4.1</QIP.1><QIP.2>CANON</QIP.2></QIP><QIP><QIP.1>@PID.5.1.1</QIP.1><QIP.2>ECG-Acharya</QIP.2></QIP><QIP><QIP.1>@PID.5.2</QIP.1><QIP.2>Nf</QIP.2></QIP><QIP><QIP.1>@PID.5.7</QIP.1><QIP.2>L</QIP.2></QIP><QIP><QIP.1>@PID.7</QIP.1><QIP.2>197104010000</QIP.2></QIP><QIP><QIP.1>@PID.8</QIP.1><QIP.2>M</QIP.2></QIP></QPD.3>   <QPD.4>100</QPD.4>   <QPD.8><CX.4><HD.2>TTH</HD.2></CX.4></QPD.8>  <QPD.9>13831</QPD.9><QPD.10>ULTIuser2</QPD.10><QPD.11>234564</QPD.11><QPD.12>R&amp;H Med</QPD.12></QPD>  <RCP>   <RCP.1>I</RCP.1>   <RCP.2><CQ.1>100</CQ.1><CQ.2>RD</CQ.2></RCP.2>   <RCP.3>   <CE.1>R</CE.1>   </RCP.3>  </RCP> </QBP_Q22>";
@@ -50,7 +50,7 @@
                 "|^~/&UHN VistaISOUHNISOMPIISOHealthLinkISO20020429132718.734-0400QBPQ22QBP_Q21855P2.4Q22Q22Find CandidatesHL7nnnn@PID.3.19583518684@PID.3.4.1CANON@PID.5.1.1ECG-Acharya@PID.5.2Nf@PID.5.7L@PID.7197104010000@PID.8M100TTH13831ULTIuser2234564R&H MedI100RDR";
 
             // Act
-            var parsed = Xml.ParseMessage(message, null, out var results);
+            var parsed = Xml.TryParseMessage(message, null, out var results);
             var actualResults = results.Select(r => r.Value).ToArray();
 
             // Assert
@@ -61,7 +61,7 @@
         [TestCase("MSH-9", "QBP")]
         [TestCase("MSH-9-2", "Q22")]
         [TestCase("QPD-8-4-2", "TTH")]
-        public void ParseMessage_ValidQBP_Q22Xml_ReturnsExpectedResult(string pathSpec, string expectedValue)
+        public void TryParseMessage_ValidQBP_Q22Xml_ReturnsExpectedResult(string pathSpec, string expectedValue)
         {
             // Arrange
             const string message = "<?xml version=\"1.0\" standalone=\"no\"?> <QBP_Q22>  <MSH>   <MSH.1>|</MSH.1>   <MSH.2>^~/&amp;</MSH.2>   <MSH.3>    <HD.1>UHN Vista</HD.1>    <HD.3>ISO</HD.3>   </MSH.3>   <MSH.4>    <HD.1>UHN</HD.1>    <HD.3>ISO</HD.3>   </MSH.4>   <MSH.5>    <HD.1>MPI</HD.1>    <HD.3>ISO</HD.3>   </MSH.5>   <MSH.6>    <HD.1>HealthLink</HD.1>    <HD.3>ISO</HD.3>   </MSH.6>   <MSH.7>20020429132718.734-0400</MSH.7>   <MSH.9>    <CM_MSG_TYPE.1>QBP</CM_MSG_TYPE.1>    <CM_MSG_TYPE.2>Q22</CM_MSG_TYPE.2>  <CM_MSG_TYPE.3>QBP_Q21</CM_MSG_TYPE.3>   </MSH.9>   <MSH.10>855</MSH.10>   <MSH.11>    <PT.1>P</PT.1>   </MSH.11>   <MSH.12>    <VID.1>2.4</VID.1>      </MSH.12>   <MSH.21>Q22</MSH.21>  </MSH>  <QPD>   <QPD.1>    <CE.1>Q22</CE.1>    <CE.2>Find Candidates</CE.2>    <CE.3>HL7nnnn</CE.3>   </QPD.1>   <QPD.3><QIP><QIP.1>@PID.3.1</QIP.1><QIP.2>9583518684</QIP.2></QIP><QIP><QIP.1>@PID.3.4.1</QIP.1><QIP.2>CANON</QIP.2></QIP><QIP><QIP.1>@PID.5.1.1</QIP.1><QIP.2>ECG-Acharya</QIP.2></QIP><QIP><QIP.1>@PID.5.2</QIP.1><QIP.2>Nf</QIP.2></QIP><QIP><QIP.1>@PID.5.7</QIP.1><QIP.2>L</QIP.2></QIP><QIP><QIP.1>@PID.7</QIP.1><QIP.2>197104010000</QIP.2></QIP><QIP><QIP.1>@PID.8</QIP.1><QIP.2>M</QIP.2></QIP></QPD.3>   <QPD.4>100</QPD.4>   <QPD.8><CX.4><HD.2>TTH</HD.2></CX.4></QPD.8>  <QPD.9>13831</QPD.9><QPD.10>ULTIuser2</QPD.10><QPD.11>234564</QPD.11><QPD.12>R&amp;H Med</QPD.12></QPD>  <RCP>   <RCP.1>I</RCP.1>   <RCP.2><CQ.1>100</CQ.1><CQ.2>RD</CQ.2></RCP.2>   <RCP.3>   <CE.1>R</CE.1>   </RCP.3>  </RCP> </QBP_Q22>";
@@ -69,7 +69,7 @@
             var pathSpecs = new List<DatumPath> { pathSpec.FromPathSpec() };
 
             // Act
-            var parsed = Xml.ParseMessage(message, pathSpecs, out var results);
+            var parsed = Xml.TryParseMessage(message, pathSpecs, out var results);
             var actualResults = results.Select(r => r.Value).ToArray();
 
             // Assert
@@ -85,7 +85,7 @@
         [TestCase("PID-5-1-1", "Smith")]
         [TestCase("MSH-9-2", "A01")]
         [TestCase("PID-5-1-2", "Booth")]
-        public void ParseMessage_ValidADT_A01Xml_ReturnsExpectedResult(string pathSpec, string expectedValue)
+        public void TryParseMessage_ValidADT_A01Xml_ReturnsExpectedResult(string pathSpec, string expectedValue)
         {
             // Arrange
             const string message = "<?xml version=\"1.0\" standalone=\"no\"?><ADT_A01 xmlns=\"urn:hl7-org:v2xml\"><MSH><MSH.1>|</MSH.1><MSH.2>^~\\&amp;</MSH.2><MSH.3><HD.1>x</HD.1></MSH.3><MSH.4><HD.1>x</HD.1></MSH.4><MSH.5><HD.1>x</HD.1></MSH.5><MSH.6><HD.1>x</HD.1></MSH.6><MSH.7><TS.1>199904140038</TS.1></MSH.7><MSH.9><MSG.1>ADT</MSG.1><MSG.2>A01</MSG.2></MSH.9><MSH.11><PT.1>P</PT.1></MSH.11><MSH.12><VID.1>2.4</VID.1></MSH.12></MSH><PID><PID.5><XPN.1><FN.1>Smith</FN.1><FN.2>Booth</FN.2><FN.3>Jones</FN.3></XPN.1><XPN.2>X</XPN.2><XPN.3>Y</XPN.3></PID.5></PID><NTE><NTE.1>a</NTE.1><NTE.3>one</NTE.3><NTE.3>two</NTE.3><NTE.3>three</NTE.3></NTE><NTE><NTE.1>b</NTE.1><NTE.3>four</NTE.3></NTE></ADT_A01>";
@@ -93,7 +93,7 @@
             var pathSpecs = new List<DatumPath> { pathSpec.FromPathSpec() };
 
             // Act
-            var parsed = Xml.ParseMessage(message, pathSpecs, out var results);
+            var parsed = Xml.TryParseMessage(message, pathSpecs, out var results);
             var actualResults = results.Select(r => r.Value).ToArray();
 
             // Assert

--- a/tests/NHapi.Base.NUnit/PreParser/XmlTests.cs
+++ b/tests/NHapi.Base.NUnit/PreParser/XmlTests.cs
@@ -58,6 +58,24 @@
             Assert.Contains(expectedValue, actualResults);
         }
 
+        [TestCase("PID-1", "grouped")]
+        [TestCase("PID(1)-1", "not grouped")]
+        public void TryParseMessage_MessageContainsSegmentGroupElements_ReturnsExpectedResult(string pathSpec, string expectedValue)
+        {
+            // Arrange
+            const string message = "<?xml version=\"1.0\" standalone=\"no\"?><root><root.group><PID>grouped</PID></root.group><PID>not grouped</PID></root>";
+
+            var pathSpecs = new List<DatumPath> { pathSpec.FromPathSpec() };
+
+            // Act
+            var parsed = Xml.TryParseMessage(message, pathSpecs, out var results);
+            var actualResults = results.Select(r => r.Value).ToArray();
+
+            // Assert
+            Assert.True(parsed);
+            Assert.Contains(expectedValue, actualResults);
+        }
+
         [TestCase("MSH-9", "QBP")]
         [TestCase("MSH-9-2", "Q22")]
         [TestCase("QPD-8-4-2", "TTH")]

--- a/tests/NHapi.Base.NUnit/PreParser/XmlTests.cs
+++ b/tests/NHapi.Base.NUnit/PreParser/XmlTests.cs
@@ -1,0 +1,104 @@
+﻿namespace NHapi.Base.NUnit.PreParser
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using global::NUnit.Framework;
+
+    using NHapi.Base.PreParser;
+
+    [TestFixture]
+    public class XmlTests
+    {
+        [Test]
+        public void ParseMessage_InvalidXml_ReturnsFalse()
+        {
+            // Arrange
+            var message = "6696A3E8-AEBE-4B7D-B2BB-3288261898A1";
+
+            var pathSpecs = Array.Empty<DatumPath>();
+
+            // Act
+            var parsed = Xml.ParseMessage(message, pathSpecs, out _);
+
+            // Assert
+            Assert.False(parsed);
+        }
+
+        [Test]
+        public void ParseMessage_ValidXml_ReturnsTrue()
+        {
+            // Arrange
+            var message = "<?xml version=\"1.0\" standalone=\"no\"?><root><child>value</child></root>";
+
+            var pathSpecs = Array.Empty<DatumPath>();
+
+            // Act
+            var parsed = Xml.ParseMessage(message, pathSpecs, out _);
+
+            // Assert
+            Assert.True(parsed);
+        }
+
+        [Test]
+        public void ParseMessage_ValidXML_NullPathSpec_ReturnsExpectedResult()
+        {
+            // Arrange
+            const string message = "<?xml version=\"1.0\" standalone=\"no\"?> <QBP_Q22>  <MSH>   <MSH.1>|</MSH.1>   <MSH.2>^~/&amp;</MSH.2>   <MSH.3>    <HD.1>UHN Vista</HD.1>    <HD.3>ISO</HD.3>   </MSH.3>   <MSH.4>    <HD.1>UHN</HD.1>    <HD.3>ISO</HD.3>   </MSH.4>   <MSH.5>    <HD.1>MPI</HD.1>    <HD.3>ISO</HD.3>   </MSH.5>   <MSH.6>    <HD.1>HealthLink</HD.1>    <HD.3>ISO</HD.3>   </MSH.6>   <MSH.7>20020429132718.734-0400</MSH.7>   <MSH.9>    <CM_MSG_TYPE.1>QBP</CM_MSG_TYPE.1>    <CM_MSG_TYPE.2>Q22</CM_MSG_TYPE.2>  <CM_MSG_TYPE.3>QBP_Q21</CM_MSG_TYPE.3>   </MSH.9>   <MSH.10>855</MSH.10>   <MSH.11>    <PT.1>P</PT.1>   </MSH.11>   <MSH.12>    <VID.1>2.4</VID.1>      </MSH.12>   <MSH.21>Q22</MSH.21>  </MSH>  <QPD>   <QPD.1>    <CE.1>Q22</CE.1>    <CE.2>Find Candidates</CE.2>    <CE.3>HL7nnnn</CE.3>   </QPD.1>   <QPD.3><QIP><QIP.1>@PID.3.1</QIP.1><QIP.2>9583518684</QIP.2></QIP><QIP><QIP.1>@PID.3.4.1</QIP.1><QIP.2>CANON</QIP.2></QIP><QIP><QIP.1>@PID.5.1.1</QIP.1><QIP.2>ECG-Acharya</QIP.2></QIP><QIP><QIP.1>@PID.5.2</QIP.1><QIP.2>Nf</QIP.2></QIP><QIP><QIP.1>@PID.5.7</QIP.1><QIP.2>L</QIP.2></QIP><QIP><QIP.1>@PID.7</QIP.1><QIP.2>197104010000</QIP.2></QIP><QIP><QIP.1>@PID.8</QIP.1><QIP.2>M</QIP.2></QIP></QPD.3>   <QPD.4>100</QPD.4>   <QPD.8><CX.4><HD.2>TTH</HD.2></CX.4></QPD.8>  <QPD.9>13831</QPD.9><QPD.10>ULTIuser2</QPD.10><QPD.11>234564</QPD.11><QPD.12>R&amp;H Med</QPD.12></QPD>  <RCP>   <RCP.1>I</RCP.1>   <RCP.2><CQ.1>100</CQ.1><CQ.2>RD</CQ.2></RCP.2>   <RCP.3>   <CE.1>R</CE.1>   </RCP.3>  </RCP> </QBP_Q22>";
+            const string expectedValue =
+                "|^~/&UHN VistaISOUHNISOMPIISOHealthLinkISO20020429132718.734-0400QBPQ22QBP_Q21855P2.4Q22Q22Find CandidatesHL7nnnn@PID.3.19583518684@PID.3.4.1CANON@PID.5.1.1ECG-Acharya@PID.5.2Nf@PID.5.7L@PID.7197104010000@PID.8M100TTH13831ULTIuser2234564R&H MedI100RDR";
+
+            // Act
+            var parsed = Xml.ParseMessage(message, null, out var results);
+            var actualResults = results.Select(r => r.Value).ToArray();
+
+            // Assert
+            Assert.True(parsed);
+            Assert.Contains(expectedValue, actualResults);
+        }
+
+        [TestCase("MSH-9", "QBP")]
+        [TestCase("MSH-9-2", "Q22")]
+        [TestCase("QPD-8-4-2", "TTH")]
+        public void ParseMessage_ValidQBP_Q22Xml_ReturnsExpectedResult(string pathSpec, string expectedValue)
+        {
+            // Arrange
+            const string message = "<?xml version=\"1.0\" standalone=\"no\"?> <QBP_Q22>  <MSH>   <MSH.1>|</MSH.1>   <MSH.2>^~/&amp;</MSH.2>   <MSH.3>    <HD.1>UHN Vista</HD.1>    <HD.3>ISO</HD.3>   </MSH.3>   <MSH.4>    <HD.1>UHN</HD.1>    <HD.3>ISO</HD.3>   </MSH.4>   <MSH.5>    <HD.1>MPI</HD.1>    <HD.3>ISO</HD.3>   </MSH.5>   <MSH.6>    <HD.1>HealthLink</HD.1>    <HD.3>ISO</HD.3>   </MSH.6>   <MSH.7>20020429132718.734-0400</MSH.7>   <MSH.9>    <CM_MSG_TYPE.1>QBP</CM_MSG_TYPE.1>    <CM_MSG_TYPE.2>Q22</CM_MSG_TYPE.2>  <CM_MSG_TYPE.3>QBP_Q21</CM_MSG_TYPE.3>   </MSH.9>   <MSH.10>855</MSH.10>   <MSH.11>    <PT.1>P</PT.1>   </MSH.11>   <MSH.12>    <VID.1>2.4</VID.1>      </MSH.12>   <MSH.21>Q22</MSH.21>  </MSH>  <QPD>   <QPD.1>    <CE.1>Q22</CE.1>    <CE.2>Find Candidates</CE.2>    <CE.3>HL7nnnn</CE.3>   </QPD.1>   <QPD.3><QIP><QIP.1>@PID.3.1</QIP.1><QIP.2>9583518684</QIP.2></QIP><QIP><QIP.1>@PID.3.4.1</QIP.1><QIP.2>CANON</QIP.2></QIP><QIP><QIP.1>@PID.5.1.1</QIP.1><QIP.2>ECG-Acharya</QIP.2></QIP><QIP><QIP.1>@PID.5.2</QIP.1><QIP.2>Nf</QIP.2></QIP><QIP><QIP.1>@PID.5.7</QIP.1><QIP.2>L</QIP.2></QIP><QIP><QIP.1>@PID.7</QIP.1><QIP.2>197104010000</QIP.2></QIP><QIP><QIP.1>@PID.8</QIP.1><QIP.2>M</QIP.2></QIP></QPD.3>   <QPD.4>100</QPD.4>   <QPD.8><CX.4><HD.2>TTH</HD.2></CX.4></QPD.8>  <QPD.9>13831</QPD.9><QPD.10>ULTIuser2</QPD.10><QPD.11>234564</QPD.11><QPD.12>R&amp;H Med</QPD.12></QPD>  <RCP>   <RCP.1>I</RCP.1>   <RCP.2><CQ.1>100</CQ.1><CQ.2>RD</CQ.2></RCP.2>   <RCP.3>   <CE.1>R</CE.1>   </RCP.3>  </RCP> </QBP_Q22>";
+
+            var pathSpecs = new List<DatumPath> { pathSpec.FromPathSpec() };
+
+            // Act
+            var parsed = Xml.ParseMessage(message, pathSpecs, out var results);
+            var actualResults = results.Select(r => r.Value).ToArray();
+
+            // Assert
+            Assert.True(parsed);
+            Assert.Contains(expectedValue, actualResults);
+        }
+
+        [TestCase("NTE(0)-1", "a")]
+        [TestCase("NTE(1)-1", "b")]
+        [TestCase("NTE-3(0)", "one")]
+        [TestCase("NTE-3(1)", "two")]
+        [TestCase("PID-5", "Smith")]
+        [TestCase("PID-5-1-1", "Smith")]
+        [TestCase("MSH-9-2", "A01")]
+        [TestCase("PID-5-1-2", "Booth")]
+        public void ParseMessage_ValidADT_A01Xml_ReturnsExpectedResult(string pathSpec, string expectedValue)
+        {
+            // Arrange
+            const string message = "<?xml version=\"1.0\" standalone=\"no\"?><ADT_A01 xmlns=\"urn:hl7-org:v2xml\"><MSH><MSH.1>|</MSH.1><MSH.2>^~\\&amp;</MSH.2><MSH.3><HD.1>x</HD.1></MSH.3><MSH.4><HD.1>x</HD.1></MSH.4><MSH.5><HD.1>x</HD.1></MSH.5><MSH.6><HD.1>x</HD.1></MSH.6><MSH.7><TS.1>199904140038</TS.1></MSH.7><MSH.9><MSG.1>ADT</MSG.1><MSG.2>A01</MSG.2></MSH.9><MSH.11><PT.1>P</PT.1></MSH.11><MSH.12><VID.1>2.4</VID.1></MSH.12></MSH><PID><PID.5><XPN.1><FN.1>Smith</FN.1><FN.2>Booth</FN.2><FN.3>Jones</FN.3></XPN.1><XPN.2>X</XPN.2><XPN.3>Y</XPN.3></PID.5></PID><NTE><NTE.1>a</NTE.1><NTE.3>one</NTE.3><NTE.3>two</NTE.3><NTE.3>three</NTE.3></NTE><NTE><NTE.1>b</NTE.1><NTE.3>four</NTE.3></NTE></ADT_A01>";
+
+            var pathSpecs = new List<DatumPath> { pathSpec.FromPathSpec() };
+
+            // Act
+            var parsed = Xml.ParseMessage(message, pathSpecs, out var results);
+            var actualResults = results.Select(r => r.Value).ToArray();
+
+            // Assert
+            Assert.True(parsed);
+            Assert.Contains(expectedValue, actualResults);
+        }
+    }
+}


### PR DESCRIPTION
As per description, should resolve #312, not sure it fully satifies the ask since the some of the methods are internal as per the source of the port. 

@AMCN41R could you review this if you get a sec?
@jakubsuchybio should be what you were looking for, well appart from `CharSetUtility.CheckCharset` being internal.